### PR TITLE
[Feature] 댄서 정보 관련 API 기능 구현

### DIFF
--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -60,7 +60,7 @@ public class DancerController {
   public ApiResponse<DancerSummaryListResponse> getDancersByGenre(
       @PathVariable("genreId") Long genreId,
       @RequestParam(defaultValue = "0") Integer page,
-      @RequestParam(defaultValue = "6") Integer size) {
+      @RequestParam(defaultValue = "9") Integer size) {
     DancerSummaryListResponse response = dancerService.getDancersByGenre(genreId, page, size);
     return ApiResponse.OK(response);
   }

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -5,6 +5,7 @@ import com.danthis.backend.api.dancer.request.DancerAddRequest;
 import com.danthis.backend.api.dancer.request.DancerUpdateRequest;
 import com.danthis.backend.application.dancer.DancerService;
 import com.danthis.backend.application.dancer.response.DancerInfoResponse;
+import com.danthis.backend.application.dancer.response.DancerSummaryListResponse;
 import com.danthis.backend.common.security.aop.AssignCurrentUserInfo;
 import com.danthis.backend.common.security.aop.CurrentUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,11 +47,21 @@ public class DancerController {
     return ApiResponse.OK(dancerId);
   }
 
-  @Operation(summary = "댄서 정보 조회 API", description = "댄서의 정보를 조회합니다.")
+  @Operation(summary = "단일 댄서 정보 조회 API", description = "댄서의 정보를 조회합니다.")
   @GetMapping("/{dancerId}")
   public ApiResponse<DancerInfoResponse> getDancerInfo(
       @PathVariable("dancerId") Long dancerId) {
     DancerInfoResponse response = dancerService.getDancerInfo(dancerId);
+    return ApiResponse.OK(response);
+  }
+
+  @Operation(summary = "장르별 댄서 정보 조회 API", description = "장르별 댄서들의 정보를 조회합니다.")
+  @GetMapping("/genres/{genreId}")
+  public ApiResponse<DancerSummaryListResponse> getDancersByGenre(
+      @PathVariable("genreId") Long genreId,
+      @RequestParam(defaultValue = "0") Integer page,
+      @RequestParam(defaultValue = "6") Integer size) {
+    DancerSummaryListResponse response = dancerService.getDancersByGenre(genreId, page, size);
     return ApiResponse.OK(response);
   }
 }

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -1,0 +1,30 @@
+package com.danthis.backend.api.dancer;
+
+import com.danthis.backend.api.ApiResponse;
+import com.danthis.backend.api.dancer.request.DancerAddRequest;
+import com.danthis.backend.application.dancer.DancerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/dancers")
+@RequiredArgsConstructor
+@Tag(name = "댄서 관리", description = "댄서 정보 관련 API")
+public class DancerController {
+
+  private final DancerService dancerService;
+
+  @Operation(summary = "댄서 정보 등록 API", description = "댄서의 정보를 새로 등록합니다.")
+  @PostMapping
+  public ApiResponse<Void> addDancer(
+      @RequestBody @Valid DancerAddRequest request) {
+    dancerService.addDancerInfo(request.toServiceRequest());
+    return ApiResponse.OK(null);
+  }
+}

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -2,12 +2,19 @@ package com.danthis.backend.api.dancer;
 
 import com.danthis.backend.api.ApiResponse;
 import com.danthis.backend.api.dancer.request.DancerAddRequest;
+import com.danthis.backend.api.dancer.request.DancerUpdateRequest;
 import com.danthis.backend.application.dancer.DancerService;
+import com.danthis.backend.application.dancer.response.DancerInfoResponse;
+import com.danthis.backend.common.security.aop.AssignCurrentUserInfo;
+import com.danthis.backend.common.security.aop.CurrentUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,9 +29,27 @@ public class DancerController {
 
   @Operation(summary = "댄서 정보 등록 API", description = "댄서의 정보를 새로 등록합니다.")
   @PostMapping
-  public ApiResponse<Void> addDancer(
+  @AssignCurrentUserInfo
+  public ApiResponse<Long> addDancer(
+      CurrentUserInfo userInfo,
       @RequestBody @Valid DancerAddRequest request) {
-    dancerService.addDancerInfo(request.toServiceRequest());
-    return ApiResponse.OK(null);
+    Long dancerId = dancerService.addDancerInfo(userInfo.getUserId(), request.toServiceRequest());
+    return ApiResponse.OK(dancerId);
+  }
+
+  @Operation(summary = "댄서 정보 수정 API", description = "댄서의 정보를 수정합니다.")
+  @PutMapping
+  public ApiResponse<Long> updateDancer(
+      @RequestBody @Valid DancerUpdateRequest request) {
+    Long dancerId = dancerService.updateDancerInfo(request.toServiceRequest());
+    return ApiResponse.OK(dancerId);
+  }
+
+  @Operation(summary = "댄서 정보 조회 API", description = "댄서의 정보를 조회합니다.")
+  @GetMapping("/{dancerId}")
+  public ApiResponse<DancerInfoResponse> getDancerInfo(
+      @PathVariable("dancerId") Long dancerId) {
+    DancerInfoResponse response = dancerService.getDancerInfo(dancerId);
+    return ApiResponse.OK(response);
   }
 }

--- a/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
+++ b/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
@@ -2,6 +2,7 @@ package com.danthis.backend.api.dancer.request;
 
 import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import lombok.Getter;
 public class DancerAddRequest {
 
   @NotBlank(message = "댄서 이름은 필수 입력값입니다.")
-  @Size(max = 50, message = "댄서 이름은 최대 50자까지 가능합니다.")
+  @Size(message = "댄서 이름은 최대 50자까지 가능합니다.")
   private String dancerName;
 
   @NotBlank(message = "인스타그램 계정은 필수 입력값입니다.")
@@ -25,10 +26,10 @@ public class DancerAddRequest {
   @NotBlank(message = "댄서 이력은 필수 입력값입니다.")
   private String history;
 
-  @NotBlank(message = "주 장르는 필수 입력값입니다.")
+  @NotEmpty(message = "주 장르는 필수 입력값입니다.")
   private Set<Long> preferredGenres;
 
-  @NotBlank(message = "댄서 사진은 필수 입력값입니다.")
+  @NotEmpty(message = "댄서 사진은 필수 입력값입니다.")
   private Set<String> dancerImages;
 
   public DancerAddServiceRequest toServiceRequest() {

--- a/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
+++ b/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
@@ -1,0 +1,39 @@
+package com.danthis.backend.api.dancer.request;
+
+import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public class DancerAddRequest {
+
+  @NotBlank(message = "댄서 이름은 필수 입력값입니다.")
+  @Size(max = 50, message = "댄서 이름은 최대 50자까지 가능합니다.")
+  private String dancerName;
+
+  private String instargramId;
+
+  private String openChatUrl;
+
+  private String bio;
+
+  private String history;
+
+  private Set<Long> preferredGenres;
+
+  private Set<String> dancerImages;
+
+  public DancerAddServiceRequest toServiceRequest() {
+    return DancerAddServiceRequest.builder()
+                                  .dancerName(dancerName)
+                                  .instargramId(instargramId)
+                                  .openChatUrl(openChatUrl)
+                                  .bio(bio)
+                                  .history(history)
+                                  .preferredGenres(preferredGenres)
+                                  .dancerImages(dancerImages)
+                                  .build();
+  }
+}

--- a/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
+++ b/src/main/java/com/danthis/backend/api/dancer/request/DancerAddRequest.java
@@ -13,16 +13,22 @@ public class DancerAddRequest {
   @Size(max = 50, message = "댄서 이름은 최대 50자까지 가능합니다.")
   private String dancerName;
 
+  @NotBlank(message = "인스타그램 계정은 필수 입력값입니다.")
   private String instargramId;
 
+  @NotBlank(message = "오픈채팅방 링크는 필수 입력값입니다.")
   private String openChatUrl;
 
+  @NotBlank(message = "한마디 소개글은 필수 입력값입니다.")
   private String bio;
 
+  @NotBlank(message = "댄서 이력은 필수 입력값입니다.")
   private String history;
 
+  @NotBlank(message = "주 장르는 필수 입력값입니다.")
   private Set<Long> preferredGenres;
 
+  @NotBlank(message = "댄서 사진은 필수 입력값입니다.")
   private Set<String> dancerImages;
 
   public DancerAddServiceRequest toServiceRequest() {

--- a/src/main/java/com/danthis/backend/api/dancer/request/DancerUpdateRequest.java
+++ b/src/main/java/com/danthis/backend/api/dancer/request/DancerUpdateRequest.java
@@ -1,0 +1,50 @@
+package com.danthis.backend.api.dancer.request;
+
+import com.danthis.backend.application.dancer.request.DancerUpdateServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public class DancerUpdateRequest {
+
+  @NotBlank(message = "댄서 ID는 필수 입력값입니다.")
+  private Long id;
+
+  @NotBlank(message = "댄서 이름은 필수 입력값입니다.")
+  @Size(max = 50, message = "댄서 이름은 최대 50자까지 가능합니다.")
+  private String dancerName;
+
+  @NotBlank(message = "인스타그램 계정은 필수 입력값입니다.")
+  private String instargramId;
+
+  @NotBlank(message = "오픈채팅방 링크는 필수 입력값입니다.")
+  private String openChatUrl;
+
+  @NotBlank(message = "한마디 소개글은 필수 입력값입니다.")
+  private String bio;
+
+  @NotBlank(message = "댄서 이력은 필수 입력값입니다.")
+  private String history;
+
+  @NotBlank(message = "주 장르는 필수 입력값입니다.")
+  private Set<Long> preferredGenres;
+
+  @NotBlank(message = "댄서 사진은 필수 입력값입니다.")
+  private Set<String> dancerImages;
+
+  public DancerUpdateServiceRequest toServiceRequest() {
+    return DancerUpdateServiceRequest.builder()
+                                     .id(id)
+                                     .dancerName(dancerName)
+                                     .instargramId(instargramId)
+                                     .openChatUrl(openChatUrl)
+                                     .bio(bio)
+                                     .history(history)
+                                     .preferredGenres(preferredGenres)
+                                     .dancerImages(dancerImages)
+                                     .build();
+  }
+}
+

--- a/src/main/java/com/danthis/backend/api/dancer/request/DancerUpdateRequest.java
+++ b/src/main/java/com/danthis/backend/api/dancer/request/DancerUpdateRequest.java
@@ -2,6 +2,8 @@ package com.danthis.backend.api.dancer.request;
 
 import com.danthis.backend.application.dancer.request.DancerUpdateServiceRequest;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
 import lombok.Getter;
@@ -9,7 +11,7 @@ import lombok.Getter;
 @Getter
 public class DancerUpdateRequest {
 
-  @NotBlank(message = "댄서 ID는 필수 입력값입니다.")
+  @NotNull(message = "댄서 ID는 필수 입력값입니다.")
   private Long id;
 
   @NotBlank(message = "댄서 이름은 필수 입력값입니다.")
@@ -28,10 +30,10 @@ public class DancerUpdateRequest {
   @NotBlank(message = "댄서 이력은 필수 입력값입니다.")
   private String history;
 
-  @NotBlank(message = "주 장르는 필수 입력값입니다.")
+  @NotEmpty(message = "주 장르는 필수 입력값입니다.")
   private Set<Long> preferredGenres;
 
-  @NotBlank(message = "댄서 사진은 필수 입력값입니다.")
+  @NotEmpty(message = "댄서 사진은 필수 입력값입니다.")
   private Set<String> dancerImages;
 
   public DancerUpdateServiceRequest toServiceRequest() {

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -1,0 +1,32 @@
+package com.danthis.backend.application.dancer;
+
+import com.danthis.backend.application.dancer.implement.DancerManager;
+import com.danthis.backend.application.dancer.implement.DancerMapper;
+import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
+import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
+import com.danthis.backend.domain.genre.Genre;
+import jakarta.transaction.Transactional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DancerService {
+
+  private final DancerManager dancerManager;
+  private final DancerMapper dancerMapper;
+
+  @Transactional
+  public void addDancerInfo(DancerAddServiceRequest request) {
+
+    Set<DancerImage> images = dancerMapper.mapToDancerImage(request.getDancerImages());
+    Set<Genre> genres = dancerMapper.mapToDancerGenre(request.getPreferredGenres());
+    Dancer dancer = request.toDancer(images, genres);
+
+    dancerManager.savedDancer(request.toDancer());
+  }
+}

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -2,10 +2,15 @@ package com.danthis.backend.application.dancer;
 
 import com.danthis.backend.application.dancer.implement.DancerManager;
 import com.danthis.backend.application.dancer.implement.DancerMapper;
+import com.danthis.backend.application.dancer.implement.DancerReader;
 import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
+import com.danthis.backend.application.dancer.request.DancerUpdateServiceRequest;
+import com.danthis.backend.application.dancer.response.DancerInfoResponse;
+import com.danthis.backend.application.user.implement.UserReader;
 import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.genre.Genre;
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import jakarta.transaction.Transactional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -18,15 +23,61 @@ import org.springframework.stereotype.Service;
 public class DancerService {
 
   private final DancerManager dancerManager;
+  private final DancerReader dancerReader;
   private final DancerMapper dancerMapper;
+  private final UserReader userReader;
 
   @Transactional
-  public void addDancerInfo(DancerAddServiceRequest request) {
+  public Long addDancerInfo(Long userId, DancerAddServiceRequest request) {
+    Dancer dancer = dancerManager.createDancer(userReader.readUserById(userId), request);
 
-    Set<DancerImage> images = dancerMapper.mapToDancerImage(request.getDancerImages());
     Set<Genre> genres = dancerMapper.mapToDancerGenre(request.getPreferredGenres());
-    Dancer dancer = request.toDancer(images, genres);
+    Set<DancerImage> images = dancerMapper.mapToDancerImage(request.getDancerImages());
 
-    dancerManager.savedDancer(request.toDancer());
+    Set<DancerGenre> dancerGenres = DancerGenre.createFromIds(dancer, genres);
+
+    dancer.updateDancerGenres(dancerGenres);
+    // Todo: 이미지 처리 필요
+
+    dancerManager.savedDancer(dancer);
+    return dancer.getId();
+  }
+
+  @Transactional
+  public Long updateDancerInfo(DancerUpdateServiceRequest request) {
+    Dancer dancer = dancerReader.readDancerById(request.getId());
+
+    Set<Genre> genres = dancerMapper.mapToDancerGenre(request.getPreferredGenres());
+
+    Set<DancerGenre> dancerGenres = DancerGenre.createFromIds(dancer, genres);
+
+    dancer.updateDancerName(request.getDancerName());
+    dancer.updateInstargramId(request.getInstargramId());
+    dancer.updateBio(request.getBio());
+    dancer.updateHistory(request.getHistory());
+    dancer.updateOpenChatUrl(request.getOpenChatUrl());
+    dancer.updateDancerGenres(dancerGenres);
+    // Todo: 이미지 처리 필요
+
+    dancerManager.savedDancer(dancer);
+    return dancer.getId();
+  }
+
+  @Transactional
+  public DancerInfoResponse getDancerInfo(Long dancerId) {
+    Dancer dancer = dancerReader.readDancerById(dancerId);
+
+    return DancerInfoResponse.builder()
+                             .id(dancer.getId())
+                             .dancerName(dancer.getDancerName())
+                             .bio(dancer.getBio())
+                             .history(dancer.getHistory())
+                             .openChatUrl(dancer.getOpenChatUrl())
+                             .favoriteGenres(dancer.getDancerGenres().stream()
+                                                   .map(dancerGenre -> dancerGenre.getGenre()
+                                                                                  .getId())
+                                                   .toList())
+                             // Todo: 이미지 처리 필요
+                             .build();
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -77,6 +77,7 @@ public class DancerService {
     return DancerInfoResponse.builder()
                              .id(dancer.getId())
                              .dancerName(dancer.getDancerName())
+                             .instargramId(dancer.getInstargramId())
                              .bio(dancer.getBio())
                              .history(dancer.getHistory())
                              .openChatUrl(dancer.getOpenChatUrl())

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -6,15 +6,21 @@ import com.danthis.backend.application.dancer.implement.DancerReader;
 import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
 import com.danthis.backend.application.dancer.request.DancerUpdateServiceRequest;
 import com.danthis.backend.application.dancer.response.DancerInfoResponse;
+import com.danthis.backend.application.dancer.response.DancerSummaryListResponse;
+import com.danthis.backend.application.dancer.response.DancerSummaryResponse;
+import com.danthis.backend.application.dancer.response.PaginationInfo;
+import com.danthis.backend.application.dancergenre.implement.DancerGenreReader;
 import com.danthis.backend.application.user.implement.UserReader;
 import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.genre.Genre;
 import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -26,30 +32,32 @@ public class DancerService {
   private final DancerReader dancerReader;
   private final DancerMapper dancerMapper;
   private final UserReader userReader;
+  private final DancerGenreReader dancerGenreReader;
 
   @Transactional
   public Long addDancerInfo(Long userId, DancerAddServiceRequest request) {
     Dancer dancer = dancerManager.createDancer(userReader.readUserById(userId), request);
+    dancerManager.saveDancer(dancer);
 
-    Set<Genre> genres = dancerMapper.mapToDancerGenre(request.getPreferredGenres());
-    Set<DancerImage> images = dancerMapper.mapToDancerImage(request.getDancerImages());
+    Set<Genre> genres = dancerMapper.mapToGenre(request.getPreferredGenres());
+    Set<DancerGenre> dancerGenres = dancerMapper.mapToDancerGenre(dancer, genres);
+    Set<DancerImage> dancerImages = dancerMapper.mapToDancerImage(dancer,
+        request.getDancerImages());
 
-    Set<DancerGenre> dancerGenres = DancerGenre.createFromIds(dancer, genres);
+    dancerManager.saveDancerGenre(dancerGenres);
+    dancerManager.saveDancerImage(dancerImages);
 
-    dancer.updateDancerGenres(dancerGenres);
-    // Todo: 이미지 처리 필요
-
-    dancerManager.savedDancer(dancer);
     return dancer.getId();
   }
 
   @Transactional
   public Long updateDancerInfo(DancerUpdateServiceRequest request) {
-    Dancer dancer = dancerReader.readDancerById(request.getId());
+    Dancer dancer = dancerReader.readById(request.getId());
 
-    Set<Genre> genres = dancerMapper.mapToDancerGenre(request.getPreferredGenres());
-
-    Set<DancerGenre> dancerGenres = DancerGenre.createFromIds(dancer, genres);
+    Set<Genre> genres = dancerMapper.mapToGenre(request.getPreferredGenres());
+    Set<DancerGenre> dancerGenres = dancerMapper.mapToDancerGenre(dancer, genres);
+    Set<DancerImage> dancerImages = dancerMapper.mapToDancerImage(dancer,
+        request.getDancerImages());
 
     dancer.updateDancerName(request.getDancerName());
     dancer.updateInstargramId(request.getInstargramId());
@@ -57,27 +65,44 @@ public class DancerService {
     dancer.updateHistory(request.getHistory());
     dancer.updateOpenChatUrl(request.getOpenChatUrl());
     dancer.updateDancerGenres(dancerGenres);
-    // Todo: 이미지 처리 필요
+    dancer.updateDancerImages(dancerImages);
 
-    dancerManager.savedDancer(dancer);
+    dancerManager.saveDancer(dancer);
     return dancer.getId();
   }
 
   @Transactional
   public DancerInfoResponse getDancerInfo(Long dancerId) {
-    Dancer dancer = dancerReader.readDancerById(dancerId);
-
+    Dancer dancer = dancerReader.readById(dancerId);
     return DancerInfoResponse.builder()
                              .id(dancer.getId())
                              .dancerName(dancer.getDancerName())
                              .bio(dancer.getBio())
                              .history(dancer.getHistory())
                              .openChatUrl(dancer.getOpenChatUrl())
-                             .favoriteGenres(dancer.getDancerGenres().stream()
+                             .favoriteGenres(dancer.getDancerGenres()
+                                                   .stream()
                                                    .map(dancerGenre -> dancerGenre.getGenre()
                                                                                   .getId())
                                                    .toList())
-                             // Todo: 이미지 처리 필요
+                             .imageUrlList(dancer.getDancerImages()
+                                                 .stream()
+                                                 .map(DancerImage::getImageUrl)
+                                                 .toList())
                              .build();
+  }
+
+  @Transactional
+  public DancerSummaryListResponse getDancersByGenre(Long genreId, Integer page, Integer size) {
+    Page<DancerGenre> pages = dancerGenreReader.readDancerGenresByGenreId(genreId, page, size);
+
+    List<Dancer> candidates = dancerReader.readByDancerGenre(pages.getContent());
+    List<DancerSummaryResponse> dancerInfos = dancerManager.toSummaryInfo(candidates);
+    PaginationInfo pagination = dancerManager.createPagination(
+        pages.getNumber(),
+        pages.getTotalPages(),
+        pages.getTotalElements());
+    
+    return dancerManager.createDancerSummaryListResponse(dancerInfos, pagination);
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -101,9 +101,8 @@ public class DancerService {
     List<DancerSummaryResponse> dancerInfos = dancerManager.toSummaryInfo(candidates);
     PaginationInfo pagination = dancerManager.createPagination(
         pages.getNumber(),
-        pages.getTotalPages(),
-        pages.getTotalElements());
-    
+        pages.getTotalPages());
+
     return dancerManager.createDancerSummaryListResponse(dancerInfos, pagination);
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -1,0 +1,17 @@
+package com.danthis.backend.application.dancer.implement;
+
+import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.repository.DancerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DancerManager {
+
+  private final DancerRepository dancerRepository;
+
+  public void savedDancer(Dancer dancer) {
+    dancerRepository.save(dancer);
+  }
+}

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -1,9 +1,19 @@
 package com.danthis.backend.application.dancer.implement;
 
 import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
+import com.danthis.backend.application.dancer.response.DancerSummaryListResponse;
+import com.danthis.backend.application.dancer.response.DancerSummaryResponse;
+import com.danthis.backend.application.dancer.response.PaginationInfo;
 import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
+import com.danthis.backend.domain.dancer.dancerimage.repository.DancerImageRepository;
 import com.danthis.backend.domain.dancer.repository.DancerRepository;
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import com.danthis.backend.domain.mapping.dancergenre.repository.DancerGenreRepository;
 import com.danthis.backend.domain.user.User;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -12,10 +22,8 @@ import org.springframework.stereotype.Component;
 public class DancerManager {
 
   private final DancerRepository dancerRepository;
-
-  public void savedDancer(Dancer dancer) {
-    dancerRepository.save(dancer);
-  }
+  private final DancerGenreRepository dancerGenreRepository;
+  private final DancerImageRepository dancerImageRepository;
 
   public Dancer createDancer(User user, DancerAddServiceRequest request) {
     Boolean permission = true;  // 모든 댄서 가입이 바로 허용된다. 나중에 false로 변경해야 함
@@ -27,5 +35,47 @@ public class DancerManager {
                  .history(request.getHistory())
                  .isApproved(permission)
                  .build();
+  }
+
+  public void saveDancer(Dancer dancer) {
+    dancerRepository.save(dancer);
+  }
+
+  public void saveDancerGenre(Set<DancerGenre> dancerGenres) {
+    dancerGenreRepository.saveAll(dancerGenres);
+  }
+
+  public void saveDancerImage(Set<DancerImage> dancerImages) {
+    dancerImageRepository.saveAll(dancerImages);
+  }
+
+  public List<DancerSummaryResponse> toSummaryInfo(List<Dancer> dancers) {
+    return dancers.stream()
+                  .map(dancer -> DancerSummaryResponse.builder()
+                                                      .id(dancer.getId())
+                                                      .dancerName(dancer.getDancerName())
+                                                      .imageUrlList(
+                                                          dancer.getDancerImages().stream()
+                                                                .map(DancerImage::getImageUrl)
+                                                                .collect(Collectors.toSet()))
+                                                      .build())
+                  .collect(Collectors.toList());
+  }
+
+  public PaginationInfo createPagination(Integer number, Integer totalPages, Long totalElements) {
+    return PaginationInfo.builder()
+                         .currentPage(number)
+                         .totalPages(totalPages)
+                         .totalResults(totalElements)
+                         .build();
+  }
+
+  public DancerSummaryListResponse createDancerSummaryListResponse(
+      List<DancerSummaryResponse> dancers,
+      PaginationInfo pagination) {
+    return DancerSummaryListResponse.builder()
+                                    .dancers(dancers)
+                                    .pagination(pagination)
+                                    .build();
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -34,6 +34,7 @@ public class DancerManager {
                  .bio(request.getBio())
                  .history(request.getHistory())
                  .isApproved(permission)
+                 .openChatUrl(request.getOpenChatUrl())
                  .build();
   }
 

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -1,7 +1,9 @@
 package com.danthis.backend.application.dancer.implement;
 
+import com.danthis.backend.application.dancer.request.DancerAddServiceRequest;
 import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.dancer.repository.DancerRepository;
+import com.danthis.backend.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,5 +15,17 @@ public class DancerManager {
 
   public void savedDancer(Dancer dancer) {
     dancerRepository.save(dancer);
+  }
+
+  public Dancer createDancer(User user, DancerAddServiceRequest request) {
+    Boolean permission = true;  // 모든 댄서 가입이 바로 허용된다. 나중에 false로 변경해야 함
+    return Dancer.builder()
+                 .user(user)
+                 .dancerName(request.getDancerName())
+                 .instargramId(request.getInstargramId())
+                 .bio(request.getBio())
+                 .history(request.getHistory())
+                 .isApproved(permission)
+                 .build();
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -63,11 +63,10 @@ public class DancerManager {
                   .collect(Collectors.toList());
   }
 
-  public PaginationInfo createPagination(Integer number, Integer totalPages, Long totalElements) {
+  public PaginationInfo createPagination(Integer number, Integer totalPages) {
     return PaginationInfo.builder()
                          .currentPage(number)
                          .totalPages(totalPages)
-                         .totalResults(totalElements)
                          .build();
   }
 

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerManager.java
@@ -60,7 +60,7 @@ public class DancerManager {
                                                                 .map(DancerImage::getImageUrl)
                                                                 .collect(Collectors.toSet()))
                                                       .build())
-                  .collect(Collectors.toList());
+                  .toList();
   }
 
   public PaginationInfo createPagination(Integer number, Integer totalPages) {

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
@@ -4,7 +4,6 @@ import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.dancer.dancerimage.repository.DancerImageRepository;
 import com.danthis.backend.domain.genre.Genre;
 import com.danthis.backend.domain.genre.repository.GenreRepository;
-import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import com.danthis.backend.domain.mapping.dancergenre.repository.DancerGenreRepository;
 import java.util.Optional;
 import java.util.Set;

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
@@ -1,10 +1,10 @@
 package com.danthis.backend.application.dancer.implement;
 
+import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
-import com.danthis.backend.domain.dancer.dancerimage.repository.DancerImageRepository;
 import com.danthis.backend.domain.genre.Genre;
 import com.danthis.backend.domain.genre.repository.GenreRepository;
-import com.danthis.backend.domain.mapping.dancergenre.repository.DancerGenreRepository;
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,19 +15,27 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DancerMapper {
 
-  private final DancerImageRepository dancerImageRepository;
-  private final DancerGenreRepository dancerGenreRepository;
   private final GenreRepository genreRepository;
 
-  public Set<DancerImage> mapToDancerImage(Set<String> imageUrls) {
+  public Set<DancerImage> mapToDancerImage(Dancer dancer, Set<String> imageUrls) {
     return imageUrls.stream()
                     .map(imageUrl -> DancerImage.builder()
+                                                .dancer(dancer)
                                                 .imageUrl(imageUrl)
                                                 .build()
                     ).collect(Collectors.toSet());
   }
 
-  public Set<Genre> mapToDancerGenre(Set<Long> genreIds) {
+  public Set<DancerGenre> mapToDancerGenre(Dancer dancer, Set<Genre> genres) {
+    return genres.stream()
+                 .map(genre -> DancerGenre.builder()
+                                          .dancer(dancer)
+                                          .genre(genre)
+                                          .build())
+                 .collect(Collectors.toSet());
+  }
+
+  public Set<Genre> mapToGenre(Set<Long> genreIds) {
     return genreIds.stream()
                    .map(genreRepository::findById)
                    .filter(Optional::isPresent)

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerMapper.java
@@ -1,0 +1,38 @@
+package com.danthis.backend.application.dancer.implement;
+
+import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
+import com.danthis.backend.domain.dancer.dancerimage.repository.DancerImageRepository;
+import com.danthis.backend.domain.genre.Genre;
+import com.danthis.backend.domain.genre.repository.GenreRepository;
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import com.danthis.backend.domain.mapping.dancergenre.repository.DancerGenreRepository;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DancerMapper {
+
+  private final DancerImageRepository dancerImageRepository;
+  private final DancerGenreRepository dancerGenreRepository;
+  private final GenreRepository genreRepository;
+
+  public Set<DancerImage> mapToDancerImage(Set<String> imageUrls) {
+    return imageUrls.stream()
+                    .map(imageUrl -> DancerImage.builder()
+                                                .imageUrl(imageUrl)
+                                                .build()
+                    ).collect(Collectors.toSet());
+  }
+
+  public Set<Genre> mapToDancerGenre(Set<Long> genreIds) {
+    return genreIds.stream()
+                   .map(genreRepository::findById)
+                   .filter(Optional::isPresent)
+                   .map(Optional::get)
+                   .collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
@@ -1,14 +1,11 @@
 package com.danthis.backend.application.dancer.implement;
 
-import com.danthis.backend.application.dancer.response.DancerSummaryResponse;
 import com.danthis.backend.common.exception.BusinessException;
 import com.danthis.backend.common.exception.ErrorCode;
 import com.danthis.backend.domain.dancer.Dancer;
-import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.dancer.repository.DancerRepository;
 import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,22 +24,5 @@ public class DancerReader {
     return dancerGenreList.stream()
                           .map(DancerGenre::getDancer)
                           .toList();
-  }
-
-  public List<DancerSummaryResponse> readDancersByDancerGenre(List<DancerGenre> dancerGenreList) {
-    List<Dancer> dancers = dancerGenreList.stream()
-                                          .map(DancerGenre::getDancer)  // Extract dancerId
-                                          .toList();
-
-    return dancers.stream()
-                  .map(dancer -> DancerSummaryResponse.builder()
-                                                      .id(dancer.getId())
-                                                      .dancerName(dancer.getDancerName())
-                                                      .imageUrlList(
-                                                          dancer.getDancerImages().stream()
-                                                                .map(DancerImage::getImageUrl)
-                                                                .collect(Collectors.toSet()))
-                                                      .build())
-                  .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
@@ -1,9 +1,14 @@
 package com.danthis.backend.application.dancer.implement;
 
+import com.danthis.backend.application.dancer.response.DancerSummaryResponse;
 import com.danthis.backend.common.exception.BusinessException;
 import com.danthis.backend.common.exception.ErrorCode;
 import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.dancer.repository.DancerRepository;
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +18,31 @@ public class DancerReader {
 
   private final DancerRepository dancerRepository;
 
-  public Dancer readDancerById(Long dancerId) {
+  public Dancer readById(Long dancerId) {
     return dancerRepository.findById(dancerId)
                            .orElseThrow(() -> new BusinessException(ErrorCode.DANCER_NOT_FOUND));
   }
 
+  public List<Dancer> readByDancerGenre(List<DancerGenre> dancerGenreList) {
+    return dancerGenreList.stream()
+                          .map(DancerGenre::getDancer)
+                          .toList();
+  }
+
+  public List<DancerSummaryResponse> readDancersByDancerGenre(List<DancerGenre> dancerGenreList) {
+    List<Dancer> dancers = dancerGenreList.stream()
+                                          .map(DancerGenre::getDancer)  // Extract dancerId
+                                          .toList();
+
+    return dancers.stream()
+                  .map(dancer -> DancerSummaryResponse.builder()
+                                                      .id(dancer.getId())
+                                                      .dancerName(dancer.getDancerName())
+                                                      .imageUrlList(
+                                                          dancer.getDancerImages().stream()
+                                                                .map(DancerImage::getImageUrl)
+                                                                .collect(Collectors.toSet()))
+                                                      .build())
+                  .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
+++ b/src/main/java/com/danthis/backend/application/dancer/implement/DancerReader.java
@@ -1,0 +1,21 @@
+package com.danthis.backend.application.dancer.implement;
+
+import com.danthis.backend.common.exception.BusinessException;
+import com.danthis.backend.common.exception.ErrorCode;
+import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.repository.DancerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DancerReader {
+
+  private final DancerRepository dancerRepository;
+
+  public Dancer readDancerById(Long dancerId) {
+    return dancerRepository.findById(dancerId)
+                           .orElseThrow(() -> new BusinessException(ErrorCode.DANCER_NOT_FOUND));
+  }
+
+}

--- a/src/main/java/com/danthis/backend/application/dancer/request/DancerAddServiceRequest.java
+++ b/src/main/java/com/danthis/backend/application/dancer/request/DancerAddServiceRequest.java
@@ -1,6 +1,10 @@
 package com.danthis.backend.application.dancer.request;
 
+import com.danthis.backend.application.user.implement.UserReader;
 import com.danthis.backend.domain.dancer.Dancer;
+import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
+import com.danthis.backend.domain.genre.Genre;
+import com.danthis.backend.domain.user.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.Set;
@@ -18,13 +22,4 @@ public class DancerAddServiceRequest {
   private String history;
   private Set<Long> preferredGenres;
   private Set<String> dancerImages;
-
-  public Dancer toDancer() {
-    return Dancer.builder()
-                 .dancerName(dancerName)
-                 .instargramId(instargramId)
-                 .bio(bio)
-                 .history(history)
-                 .build();
-  }
 }

--- a/src/main/java/com/danthis/backend/application/dancer/request/DancerAddServiceRequest.java
+++ b/src/main/java/com/danthis/backend/application/dancer/request/DancerAddServiceRequest.java
@@ -1,0 +1,30 @@
+package com.danthis.backend.application.dancer.request;
+
+import com.danthis.backend.domain.dancer.Dancer;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DancerAddServiceRequest {
+
+  private String dancerName;
+  private String instargramId;
+  private String openChatUrl;
+  private String bio;
+  private String history;
+  private Set<Long> preferredGenres;
+  private Set<String> dancerImages;
+
+  public Dancer toDancer() {
+    return Dancer.builder()
+                 .dancerName(dancerName)
+                 .instargramId(instargramId)
+                 .bio(bio)
+                 .history(history)
+                 .build();
+  }
+}

--- a/src/main/java/com/danthis/backend/application/dancer/request/DancerUpdateServiceRequest.java
+++ b/src/main/java/com/danthis/backend/application/dancer/request/DancerUpdateServiceRequest.java
@@ -1,0 +1,21 @@
+package com.danthis.backend.application.dancer.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DancerUpdateServiceRequest {
+
+  private Long id;
+  private String dancerName;
+  private String instargramId;
+  private String openChatUrl;
+  private String bio;
+  private String history;
+  private Set<Long> preferredGenres;
+  private Set<String> dancerImages;
+}

--- a/src/main/java/com/danthis/backend/application/dancer/response/DancerInfoResponse.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/DancerInfoResponse.java
@@ -15,5 +15,5 @@ public class DancerInfoResponse {
   private String history;
   private String openChatUrl;
   private List<Long> favoriteGenres;
-  private List<Long> imageUrlList;
+  private List<String> imageUrlList;
 }

--- a/src/main/java/com/danthis/backend/application/dancer/response/DancerInfoResponse.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/DancerInfoResponse.java
@@ -1,0 +1,19 @@
+package com.danthis.backend.application.dancer.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DancerInfoResponse {
+
+  private Long id;
+  private String dancerName;
+  private String instargramId;
+  private String bio;
+  private String history;
+  private String openChatUrl;
+  private List<Long> favoriteGenres;
+  private List<Long> imageUrlList;
+}

--- a/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryListResponse.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryListResponse.java
@@ -1,0 +1,13 @@
+package com.danthis.backend.application.dancer.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DancerSummaryListResponse {
+
+  private List<DancerSummaryResponse> dancers;
+  private PaginationInfo pagination;
+}

--- a/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryResponse.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.danthis.backend.application.dancer.response;
+
+import java.util.List;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DancerSummaryResponse {
+
+  private Long id;
+  private String dancerName;
+  private Set<String> imageUrlList;
+}

--- a/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryResponse.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/DancerSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.danthis.backend.application.dancer.response;
 
-import java.util.List;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/danthis/backend/application/dancer/response/PaginationInfo.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/PaginationInfo.java
@@ -1,0 +1,13 @@
+package com.danthis.backend.application.dancer.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaginationInfo {
+
+  private Integer currentPage;
+  private Integer totalPages;
+  private Long totalResults;
+}

--- a/src/main/java/com/danthis/backend/application/dancer/response/PaginationInfo.java
+++ b/src/main/java/com/danthis/backend/application/dancer/response/PaginationInfo.java
@@ -9,5 +9,4 @@ public class PaginationInfo {
 
   private Integer currentPage;
   private Integer totalPages;
-  private Long totalResults;
 }

--- a/src/main/java/com/danthis/backend/application/dancergenre/implement/DancerGenreReader.java
+++ b/src/main/java/com/danthis/backend/application/dancergenre/implement/DancerGenreReader.java
@@ -1,0 +1,22 @@
+package com.danthis.backend.application.dancergenre.implement;
+
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import com.danthis.backend.domain.mapping.dancergenre.repository.DancerGenreRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DancerGenreReader {
+
+  private final DancerGenreRepository dancerGenreRepository;
+
+  public Page<DancerGenre> readDancerGenresByGenreId(Long genreId, Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page, size);
+    return dancerGenreRepository.findByGenreId(genreId, pageable);
+  }
+}

--- a/src/main/java/com/danthis/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/danthis/backend/common/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode {
   INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
   INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
   NOT_EXIST_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "존재하지 않는 리프레시 토큰입니다."),
-  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  DANCER_NOT_FOUND(HttpStatus.NOT_FOUND, "댄서를 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
+++ b/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
@@ -5,6 +5,7 @@ import com.danthis.backend.domain.danceclass.DanceClass;
 import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import com.danthis.backend.domain.mapping.userdancer.UserDancer;
+import com.danthis.backend.domain.mapping.usergenre.UserGenre;
 import com.danthis.backend.domain.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -65,4 +66,41 @@ public class Dancer extends BaseEntity {
 
   @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY)
   private Set<UserDancer> userDancers;
+
+  public void updateDancerName(String dancerName) {
+    this.dancerName = dancerName;
+  }
+
+  public void updateInstargramId(String instargramId) {
+    this.instargramId = instargramId;
+  }
+
+  public void updateBio(String bio) {
+    this.bio = bio;
+  }
+
+  public void updateHistory(String history) {
+    this.history = history;
+  }
+
+  public void updateDancerImage(String dancerImage) {
+  }
+
+  public void updateOpenChatUrl(String openChatUrl) {
+    this.openChatUrl = openChatUrl;
+  }
+
+  public void updateIsApproved(Boolean permission) {
+    this.isApproved = permission;
+  }
+
+  public void updateDancerGenres(Set<DancerGenre> genres) {
+    this.dancerGenres.clear();
+    this.dancerGenres.addAll(genres);
+  }
+
+  public void updateDancerImages(Set<DancerImage> images) {
+    this.dancerImages.clear();
+    this.dancerImages.addAll(images);
+  }
 }

--- a/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
+++ b/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
@@ -5,8 +5,8 @@ import com.danthis.backend.domain.danceclass.DanceClass;
 import com.danthis.backend.domain.dancer.dancerimage.DancerImage;
 import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
 import com.danthis.backend.domain.mapping.userdancer.UserDancer;
-import com.danthis.backend.domain.mapping.usergenre.UserGenre;
 import com.danthis.backend.domain.user.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -54,10 +54,10 @@ public class Dancer extends BaseEntity {
 
   private Boolean isApproved;
 
-  @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<DancerGenre> dancerGenres;
 
-  @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY)
+  @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<DancerImage> dancerImages;
 
   @OneToMany(mappedBy = "dancer", fetch = FetchType.LAZY)

--- a/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
+++ b/src/main/java/com/danthis/backend/domain/dancer/Dancer.java
@@ -40,17 +40,16 @@ public class Dancer extends BaseEntity {
   @Column(nullable = false, length = 50)
   private String dancerName;
 
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 20)
   private String instargramId;
 
-  @Column(nullable = false, length = 10)
+  @Column(nullable = false, length = 80)
   private String bio;
 
-  @Column(nullable = false, length = 10)
+  @Column(nullable = false, length = 1000)
   private String history;
 
-  private String dancerImage;
-
+  @Column(nullable = false, length = 255)
   private String openChatUrl;
 
   private Boolean isApproved;
@@ -81,9 +80,6 @@ public class Dancer extends BaseEntity {
 
   public void updateHistory(String history) {
     this.history = history;
-  }
-
-  public void updateDancerImage(String dancerImage) {
   }
 
   public void updateOpenChatUrl(String openChatUrl) {

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
@@ -4,6 +4,8 @@ import com.danthis.backend.domain.BaseEntity;
 import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.genre.Genre;
 import jakarta.persistence.*;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,4 +29,13 @@ public class DancerGenre extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "genre_id")
   private Genre genre;
+
+  public static Set<DancerGenre> createFromIds(Dancer dancer, Set<Genre> genres) {
+    return genres.stream()
+                 .map(genre -> DancerGenre.builder()
+                                          .dancer(dancer)
+                                          .genre(genre)
+                                          .build())
+                 .collect(Collectors.toSet());
+  }
 }

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
@@ -29,13 +29,4 @@ public class DancerGenre extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "genre_id")
   private Genre genre;
-
-  public static Set<DancerGenre> createFromIds(Dancer dancer, Set<Genre> genres) {
-    return genres.stream()
-                 .map(genre -> DancerGenre.builder()
-                                          .dancer(dancer)
-                                          .genre(genre)
-                                          .build())
-                 .collect(Collectors.toSet());
-  }
 }

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/DancerGenre.java
@@ -4,8 +4,6 @@ import com.danthis.backend.domain.BaseEntity;
 import com.danthis.backend.domain.dancer.Dancer;
 import com.danthis.backend.domain.genre.Genre;
 import jakarta.persistence.*;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepository.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DancerGenreRepository extends JpaRepository<DancerGenre, Long> {
+public interface DancerGenreRepository extends JpaRepository<DancerGenre, Long>,
+    DancerGenreRepositoryCustom {
+
 }

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryCustom.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.danthis.backend.domain.mapping.dancergenre.repository;
+
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface DancerGenreRepositoryCustom {
+
+  Page<DancerGenre> findByGenreId(Long genreId, Pageable pageable);
+}

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryImpl.java
@@ -25,15 +25,10 @@ public class DancerGenreRepositoryImpl implements DancerGenreRepositoryCustom {
                                                     .limit(pageable.getPageSize())
                                                     .fetch();
 
-    Long total = jpaQueryFactory.select(dancerGenre.count())
-                                .from(dancerGenre)
-                                .where(dancerGenre.genre.id.eq(genreId))
-                                .fetchOne();
+    Long totalElements = jpaQueryFactory.selectFrom(dancerGenre)
+                                        .where(dancerGenre.genre.id.eq(genreId))
+                                        .fetchCount();
 
-    if (total == null) {
-      total = 0L;
-    }
-
-    return new PageImpl<>(dancerGenres, pageable, total);
+    return new PageImpl<>(dancerGenres, pageable, totalElements);
   }
 }

--- a/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/mapping/dancergenre/repository/DancerGenreRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.danthis.backend.domain.mapping.dancergenre.repository;
+
+import com.danthis.backend.domain.mapping.dancergenre.DancerGenre;
+import com.danthis.backend.domain.mapping.dancergenre.QDancerGenre;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DancerGenreRepositoryImpl implements DancerGenreRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  private final QDancerGenre dancerGenre = QDancerGenre.dancerGenre;
+
+  @Override
+  public Page<DancerGenre> findByGenreId(Long genreId, Pageable pageable) {
+    List<DancerGenre> dancerGenres = jpaQueryFactory.selectFrom(dancerGenre)
+                                                    .where(dancerGenre.genre.id.eq(genreId))
+                                                    .offset(pageable.getOffset())
+                                                    .limit(pageable.getPageSize())
+                                                    .fetch();
+
+    Long total = jpaQueryFactory.select(dancerGenre.count())
+                                .from(dancerGenre)
+                                .where(dancerGenre.genre.id.eq(genreId))
+                                .fetchOne();
+
+    if (total == null) {
+      total = 0L;
+    }
+
+    return new PageImpl<>(dancerGenres, pageable, total);
+  }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
#19

## 📝 작업 내용
* 댄서 등록, 수정, 조회 API 구현
* 장르에 맞는 댄서들 조회 API 구현

## 💬 리뷰 요구 사항
장르에 맞는 댄서들 조회 API 로직에 대해 리뷰를 부탁드립니다.
대략적인 서비스 구현은 아래와 같습니다.
1. dancerGenre 테이블에서 genre-id에 맞는 객체들을 pageable 정보에 맞춰 가져옵니다.
2. 가져온 dancerGenre 리스트를 dancer 리스트로 변환합니다.
3. dancer리스트를 dacnerSummaryResponse 리스트로 변환합니다.
4. paginationDTO와 dancerSummaryResponse 리스트를 하나의 dancerSummaryListResponse로 포장합니다.
5. dancerSummaryListResponse를 data로 보냅니다.
