### PR TITLE
[Feature] 해시태그 검색 및 커뮤니티 삭제 기능 구현

### DIFF
--- a/src/main/java/com/danthis/backend/api/search/SearchController.java
+++ b/src/main/java/com/danthis/backend/api/search/SearchController.java
@@ -32,7 +32,8 @@ public class SearchController {
       @RequestParam(defaultValue = "1") @Min(1) int page,
       @RequestParam(defaultValue = "5") @Min(1) int size
   ) {
-    ClassSearchServiceResponse response = searchService.searchDanceClassesFlexibly(query, hashtagId, page, size);
+    ClassSearchServiceResponse response = searchService.searchDanceClassesFlexibly(query, hashtagId,
+        page, size);
     return ApiResponse.OK(response);
   }
 

--- a/src/main/java/com/danthis/backend/api/search/SearchController.java
+++ b/src/main/java/com/danthis/backend/api/search/SearchController.java
@@ -24,18 +24,15 @@ public class SearchController {
 
   private final SearchService searchService;
 
-  @Operation(summary = "댄스 수업 검색 API", description = "검색어를 포함한 댄스 수업 목록을 조회합니다.")
+  @Operation(summary = "댄스 수업 검색 API(제목, 해시태그, 또는 둘 다)", description = "제목과 해시태그를 기반으로 댄스 수업을 조회합니다.")
   @GetMapping("/dance-classes")
   public ApiResponse<ClassSearchServiceResponse> searchDanceClasses(
-      @RequestParam String query,
+      @RequestParam(required = false) String query,
+      @RequestParam(required = false) Long hashtagId,
       @RequestParam(defaultValue = "1") @Min(1) int page,
       @RequestParam(defaultValue = "5") @Min(1) int size
   ) {
-    if (query.trim().isEmpty()) {
-      throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
-    }
-
-    ClassSearchServiceResponse response = searchService.searchDanceClasses(query, page, size);
+    ClassSearchServiceResponse response = searchService.searchDanceClassesFlexibly(query, hashtagId, page, size);
     return ApiResponse.OK(response);
   }
 

--- a/src/main/java/com/danthis/backend/application/community/CommentService.java
+++ b/src/main/java/com/danthis/backend/application/community/CommentService.java
@@ -13,6 +13,7 @@ import com.danthis.backend.domain.communitycomment.CommunityComment;
 import com.danthis.backend.domain.communitypost.CommunityPost;
 import com.danthis.backend.domain.user.User;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -56,5 +57,11 @@ public class CommentService {
     }
 
     commentManager.deleteComment(comment);
+  }
+
+  @Transactional
+  public void deleteCommentsByPostId(Long postId) {
+    List<CommunityComment> comments = commentReader.readCommentsByPostId(postId);
+    comments.forEach(commentManager::deleteComment);
   }
 }

--- a/src/main/java/com/danthis/backend/application/community/PostService.java
+++ b/src/main/java/com/danthis/backend/application/community/PostService.java
@@ -29,6 +29,7 @@ public class PostService {
   private final PostReader postReader;
   private final PostImageManager postImageManager;
   private final UserReader userReader;
+  private final CommentService commentService;
 
   @Transactional
   public void createPost(PostCreateServiceRequest request) {
@@ -63,6 +64,7 @@ public class PostService {
       throw new BusinessException(ErrorCode.ACCESS_DENIED);
     }
 
+    commentService.deleteCommentsByPostId(postId);
     postImageManager.deletePostImages(postId);
     postManager.deletePost(post);
   }

--- a/src/main/java/com/danthis/backend/application/community/implement/CommentReader.java
+++ b/src/main/java/com/danthis/backend/application/community/implement/CommentReader.java
@@ -4,6 +4,7 @@ import com.danthis.backend.common.exception.BusinessException;
 import com.danthis.backend.common.exception.ErrorCode;
 import com.danthis.backend.domain.communitycomment.CommunityComment;
 import com.danthis.backend.domain.communitycomment.repository.CommunityCommentRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,5 +23,9 @@ public class CommentReader {
   public CommunityComment readCommentById(Long commentId) {
     return communityCommentRepository.findById(commentId)
                                      .orElseThrow(() -> new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+  }
+
+  public List<CommunityComment> readCommentsByPostId(Long postId) {
+    return communityCommentRepository.findByPostId(postId);
   }
 }

--- a/src/main/java/com/danthis/backend/application/file/response/GetPresignedUrlResponse.java
+++ b/src/main/java/com/danthis/backend/application/file/response/GetPresignedUrlResponse.java
@@ -20,7 +20,7 @@ public class GetPresignedUrlResponse {
     return GetPresignedUrlResponse.builder()
                                   .presignedUrl(presignedUrl)
                                   .fileUrl(
-                                      "https://danthis/s3.ap-northeast-2.amazonaws.com/" + fileUrl)
+                                      "https://danthis.s3.ap-northeast-2.amazonaws.com/" + fileUrl)
                                   .build();
   }
 }

--- a/src/main/java/com/danthis/backend/application/search/SearchService.java
+++ b/src/main/java/com/danthis/backend/application/search/SearchService.java
@@ -24,15 +24,15 @@ public class SearchService {
   private final SearchReader searchReader;
 
   @Transactional
-  public ClassSearchServiceResponse searchDanceClasses(String query, int page, int size) {
-    if (query == null || query.trim().isEmpty()) {
+  public ClassSearchServiceResponse searchDanceClassesFlexibly(String query, Long hashtagId, int page, int size) {
+    if ((query == null || query.trim().isEmpty()) && hashtagId == null) {
       throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
     }
 
     PageRequest pageable = PageRequest.of(page - 1, size);
-    Page<DanceClass> danceClassPage = searchReader.searchDanceClasses(query, pageable);
+    Page<DanceClass> danceClassPage = searchReader.findClassesByTitleAndHashtag(query, hashtagId, pageable);
 
-    return ClassSearchServiceResponse.from(query, danceClassPage);
+    return ClassSearchServiceResponse.from("Flexible Search", danceClassPage);
   }
 
   @Transactional

--- a/src/main/java/com/danthis/backend/application/search/SearchService.java
+++ b/src/main/java/com/danthis/backend/application/search/SearchService.java
@@ -24,13 +24,15 @@ public class SearchService {
   private final SearchReader searchReader;
 
   @Transactional
-  public ClassSearchServiceResponse searchDanceClassesFlexibly(String query, Long hashtagId, int page, int size) {
+  public ClassSearchServiceResponse searchDanceClassesFlexibly(String query, Long hashtagId,
+      int page, int size) {
     if ((query == null || query.trim().isEmpty()) && hashtagId == null) {
       throw new BusinessException(ErrorCode.INVALID_SEARCH_QUERY);
     }
 
     PageRequest pageable = PageRequest.of(page - 1, size);
-    Page<DanceClass> danceClassPage = searchReader.findClassesByTitleAndHashtag(query, hashtagId, pageable);
+    Page<DanceClass> danceClassPage = searchReader.findClassesByTitleAndHashtag(query, hashtagId,
+        pageable);
 
     return ClassSearchServiceResponse.from("Flexible Search", danceClassPage);
   }

--- a/src/main/java/com/danthis/backend/application/search/implement/SearchReader.java
+++ b/src/main/java/com/danthis/backend/application/search/implement/SearchReader.java
@@ -19,7 +19,8 @@ public class SearchReader {
   private final DancerRepository dancerRepository;
   private final CommunityPostRepository communityPostRepository;
 
-  public Page<DanceClass> findClassesByTitleAndHashtag(String query, Long hashtagId, PageRequest pageable) {
+  public Page<DanceClass> findClassesByTitleAndHashtag(String query, Long hashtagId,
+      PageRequest pageable) {
     return danceClassRepository.findByClassNameAndHashtag(query, hashtagId, pageable);
   }
 

--- a/src/main/java/com/danthis/backend/application/search/implement/SearchReader.java
+++ b/src/main/java/com/danthis/backend/application/search/implement/SearchReader.java
@@ -19,8 +19,8 @@ public class SearchReader {
   private final DancerRepository dancerRepository;
   private final CommunityPostRepository communityPostRepository;
 
-  public Page<DanceClass> searchDanceClasses(String query, PageRequest pageable) {
-    return danceClassRepository.searchByClassName(query, pageable);
+  public Page<DanceClass> findClassesByTitleAndHashtag(String query, Long hashtagId, PageRequest pageable) {
+    return danceClassRepository.findByClassNameAndHashtag(query, hashtagId, pageable);
   }
 
   public Page<Dancer> searchDancers(String query, PageRequest pageable) {

--- a/src/main/java/com/danthis/backend/application/search/response/ClassSearchServiceResponse.java
+++ b/src/main/java/com/danthis/backend/application/search/response/ClassSearchServiceResponse.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Page;
 @Builder
 public class ClassSearchServiceResponse {
 
-  private String query;
+  private String searchType;
   private List<DanceClassSummary> results;
   private Pagination pagination;
 
@@ -18,7 +18,7 @@ public class ClassSearchServiceResponse {
   @Builder
   public static class DanceClassSummary {
 
-    private Long id;
+    private Long classId;
     private String className;
     private String dancer;
     private Long genre;
@@ -36,11 +36,11 @@ public class ClassSearchServiceResponse {
     private long totalResults;
   }
 
-  public static ClassSearchServiceResponse from(String query, Page<DanceClass> danceClassPage) {
+  public static ClassSearchServiceResponse from(String searchType, Page<DanceClass> danceClassPage) {
     List<DanceClassSummary> danceClassSummaries = danceClassPage.getContent().stream()
                                                                 .map(
                                                                     danceClass -> DanceClassSummary.builder()
-                                                                                                   .id(danceClass.getId())
+                                                                                                   .classId(danceClass.getId())
                                                                                                    .className(danceClass.getClassName())
                                                                                                    .dancer(danceClass.getDancer().getDancerName())
                                                                                                    .genre(danceClass.getGenre().getId())
@@ -60,7 +60,7 @@ public class ClassSearchServiceResponse {
                                           .build();
 
     return ClassSearchServiceResponse.builder()
-                                     .query(query)
+                                     .searchType(searchType)
                                      .results(danceClassSummaries)
                                      .pagination(paginationInfo)
                                      .build();

--- a/src/main/java/com/danthis/backend/domain/communitycomment/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/danthis/backend/domain/communitycomment/repository/CommunityCommentRepository.java
@@ -1,6 +1,7 @@
 package com.danthis.backend.domain.communitycomment.repository;
 
 import com.danthis.backend.domain.communitycomment.CommunityComment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long>,
     CommunityCommentRepositoryCustom {
 
+  List<CommunityComment> findByPostId(Long postId);
 }

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepository.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepository.java
@@ -4,6 +4,7 @@ import com.danthis.backend.domain.danceclass.DanceClass;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +14,13 @@ public interface DanceClassRepository extends JpaRepository<DanceClass, Long>,
   Page<DanceClass> findByGenreId(Long genreId, Pageable pageable);
 
   Page<DanceClass> findByDancerId(Long dancerId, Pageable pageable);
+
+  @Query("""
+          SELECT DISTINCT dc FROM DanceClass dc 
+          LEFT JOIN dc.danceClassHashtags dh 
+          WHERE (:query IS NULL OR LOWER(dc.className) LIKE LOWER(CONCAT('%', :query, '%')))
+          AND (:hashtagId IS NULL OR dh.hashtag.id = :hashtagId)
+          ORDER BY dc.id ASC
+      """)
+  Page<DanceClass> findByClassNameAndHashtag(String query, Long hashtagId, Pageable pageable);
 }

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryCustom.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryCustom.java
@@ -1,10 +1,5 @@
 package com.danthis.backend.domain.danceclass.repository;
 
-import com.danthis.backend.domain.danceclass.DanceClass;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 public interface DanceClassRepositoryCustom {
 
-  Page<DanceClass> searchByClassName(String query, Pageable pageable);
 }

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
@@ -1,39 +1,10 @@
 package com.danthis.backend.domain.danceclass.repository;
 
-import static com.danthis.backend.domain.danceclass.QDanceClass.danceClass;
-
-import com.danthis.backend.domain.danceclass.DanceClass;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class DanceClassRepositoryImpl implements DanceClassRepositoryCustom {
 
-  private final JPAQueryFactory jpaQueryFactory;
-
-  @Override
-  public Page<DanceClass> searchByClassName(String query, Pageable pageable) {
-    BooleanExpression searchCondition = danceClass.className.containsIgnoreCase(query)
-                                                            .and(danceClass.isActive.eq(true));
-
-    List<DanceClass> results = jpaQueryFactory.selectFrom(danceClass)
-                                              .where(searchCondition)
-                                              .offset(pageable.getOffset())
-                                              .limit(pageable.getPageSize())
-                                              .fetch();
-
-    long total = jpaQueryFactory.select(danceClass.count())
-                                .from(danceClass)
-                                .where(searchCondition)
-                                .fetchOne();
-
-    return new PageImpl<>(results, pageable, total);
-  }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
#62 


## 📝 작업 내용
1. 검색 기능
원래 해시태그 관련 검색, 댄스 수업 제목 검색 따로따로 구분했는데, 승민이랑 얘기하니까 둘 다 적용되는 케이스도 있어야 할 것 같아서 그냥 하나의 API에다가 [해시태그만 한 경우, 제목만 검색한 경우, 둘 다 적용된 경우] 이렇게 3가지 케이스 넣어서 정리하였습니다.

2. 커뮤니티 삭제 기능
게시글 삭제할 경우, 해당 댓글도 같이 삭제하게 설정하였습니다.

3. PresignedUrl 경로 수정
객체 url 주소가 잘못 되어서 수정하였습니다.

## 💬 리뷰 요구 사항
레포지토리 보면 JPQL을 작성했는데, 제가 진짜 최대한 querydsl를 활용하려고 해봤는데 계속 오류가 나서 어쩔 수 없이 저렇게 작성했어요,,,,,,ㅠㅠㅠㅠㅠ 너무 제가 모자르다고 느껴집니다.... 나중에 시간나면 리팩토링 다시 해보겠습니다. 혹시 좋은 아이디어 있으면 나눠주세용
