### PR TITLE
[Feature] 댄서 아이디로 댄서가 등록한 수업 조회 기능 구현

### DIFF
--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -85,10 +85,11 @@ public class DancerController {
   @AssignCurrentUserInfo
   public ApiResponse<DanceClassListServiceResponse> getDancerClasses(
       CurrentUserInfo userInfo,
+      @RequestParam(defaultValue = "0") @Min(0) long dancerId,
       @RequestParam(defaultValue = "1") @Min(1) int page,
       @RequestParam(defaultValue = "9") @Min(1) int size) {
 
-    DanceClassListServiceResponse response = danceClassService.getDancerClasses(userInfo.getUserId(), page, size);
+    DanceClassListServiceResponse response = danceClassService.getDancerClasses(userInfo.getUserId(), dancerId, page, size);
     return ApiResponse.OK(response);
   }
 }

--- a/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
+++ b/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
@@ -128,9 +128,13 @@ public class DanceClassService {
   }
 
   @Transactional
-  public DanceClassListServiceResponse getDancerClasses(Long userId, Integer page, Integer size) {
+  public DanceClassListServiceResponse getDancerClasses(Long userId, Long dancerId, Integer page, Integer size) {
     PageRequest pageable = PageRequest.of(page - 1, size);
-    Dancer dancer = dancerReader.readDancerByUserId(userId);
+
+    Dancer dancer = (dancerId == 0)
+        ? dancerReader.readDancerByUserId(userId) // 댄서 아이디가 0인 경우, 유저의 댄서 정보 조회
+        : dancerReader.readDancerById(dancerId);  // 댄서 아이디가 있는 경우, 해당 댄서의 정보 조회
+
     if (dancer == null) {
       throw new BusinessException(ErrorCode.DANCER_NOT_FOUND);
     }

--- a/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
+++ b/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
@@ -130,10 +130,10 @@ public class DanceClassService {
   @Transactional
   public DanceClassListServiceResponse getDancerClasses(Long userId, Long dancerId, Integer page, Integer size) {
     PageRequest pageable = PageRequest.of(page - 1, size);
-
-    Dancer dancer = (dancerId == 0)
-        ? dancerReader.readDancerByUserId(userId) // 댄서 아이디가 0인 경우, 유저의 댄서 정보 조회
-        : dancerReader.readDancerById(dancerId);  // 댄서 아이디가 있는 경우, 해당 댄서의 정보 조회
+    Dancer dancer = dancerReader.readDancerByUserId(userId);
+    if (dancerId != 0) {
+      dancer = dancerReader.readDancerById(dancerId);
+    }
 
     if (dancer == null) {
       throw new BusinessException(ErrorCode.DANCER_NOT_FOUND);


### PR DESCRIPTION
## 💡 연관된 이슈
#68

## 📝 작업 내용
기존에 제작했던 `댄서가 등록한 수업 조회 API`는 유저 id로 댄서를 찾아서 등록한 수업을 반환했는데,
가형이가 만드는 기능 중 다른 댄서가 등록한 수업을 댄서id로 찾아서 반환해야하는 기능이 필요했습니다.
그래서 기존에 구현했던 API에 쿼리파라미터로 댄서id를 받아서 로직을 개선했습니다.

## 💬 리뷰 요구 사항
댄서 id의 인풋 유무에 따라 사용하는 함수가 다르기 때문에 삼항연산자를 사용했습니다.
코드컨벤션중에 삼항연산자 사용을 지양하라는 내용이 있었지만 마땅한 방법이 안떠올랐습니다. 
어떻게 개선하면 좋을지 피드백 부탁드립니다.
