### PR TITLE
[Fix] 비로그인 상태에서 dancer 조회 api가 가능하도록 수정

### DIFF
--- a/src/main/java/com/danthis/backend/api/community/CommunityController.java
+++ b/src/main/java/com/danthis/backend/api/community/CommunityController.java
@@ -69,7 +69,9 @@ public class CommunityController {
   @Operation(summary = "게시글 단일 조회", description = "게시글을 단일 조회합니다.")
   @GetMapping("/posts/{postId}")
   public ApiResponse<PostReadServiceResponse> getPost(@PathVariable Long postId) {
-    return ApiResponse.OK(postService.getPostById(postId));
+
+    PostReadServiceResponse response = postService.getPostById(postId);
+    return ApiResponse.OK(response);
   }
 
   @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")

--- a/src/main/java/com/danthis/backend/api/community/CommunityController.java
+++ b/src/main/java/com/danthis/backend/api/community/CommunityController.java
@@ -67,7 +67,7 @@ public class CommunityController {
   }
 
   @Operation(summary = "게시글 단일 조회", description = "게시글을 단일 조회합니다.")
-  @GetMapping("/posts/{postId}")
+  @GetMapping("/info/posts/{postId}")
   public ApiResponse<PostReadServiceResponse> getPost(@PathVariable Long postId) {
 
     PostReadServiceResponse response = postService.getPostById(postId);
@@ -75,7 +75,7 @@ public class CommunityController {
   }
 
   @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
-  @GetMapping("/posts")
+  @GetMapping("/info/posts")
   public ApiResponse<PostListServiceResponse> getPosts(
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "10") int size
@@ -96,7 +96,7 @@ public class CommunityController {
   }
 
   @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글을 조회합니다.")
-  @GetMapping("/posts/{postId}/comments")
+  @GetMapping("/info/posts/{postId}/comments")
   public ApiResponse<CommentListServiceResponse> getComments(
       @PathVariable Long postId,
       @RequestParam(defaultValue = "1") int page,

--- a/src/main/java/com/danthis/backend/api/danceclass/DanceClassController.java
+++ b/src/main/java/com/danthis/backend/api/danceclass/DanceClassController.java
@@ -66,7 +66,7 @@ public class DanceClassController {
   }
 
   @Operation(summary = "댄스 수업 단일 조회 상세 설명 API", description = "댄스 수업 상세 설명 섹션을 조회합니다.")
-  @GetMapping("/{classId}")
+  @GetMapping("/info/{classId}")
   @AssignCurrentUserInfo
   public ApiResponse<DanceClassReadServiceResponse> getDanceClassDetails(
       @PathVariable Long classId) {
@@ -75,7 +75,7 @@ public class DanceClassController {
   }
 
   @Operation(summary = "댄스 수업 단일 조회 리뷰 목록 API", description = "댄스 수업 리뷰 목록 섹션을 조회합니다.")
-  @GetMapping("/{classId}/reviews")
+  @GetMapping("/info/{classId}/reviews")
   @AssignCurrentUserInfo
   public ApiResponse<DanceClassReadServiceResponse> getDanceClassReviews(
       @PathVariable Long classId,
@@ -88,7 +88,7 @@ public class DanceClassController {
   }
 
   @Operation(summary = "댄스 수업 평균 별점 조회 API", description = "댄스 수업의 전체 평균 별점을 조회합니다.")
-  @GetMapping("{classId}/rating")
+  @GetMapping("/info/{classId}/rating")
   @AssignCurrentUserInfo
   public ApiResponse<DanceClassReadServiceResponse> getDanceClassAverageRating(
       @PathVariable Long classId) {

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -90,8 +90,8 @@ public class DancerController {
   }
 
   @Operation(summary = "댄서가 생성한 댄스수업 목록 조회 API", description = "댄서가 생성한 댄스수업 목록을 조회합니다.")
-  @GetMapping("/dance-classes")
-  @AssignCurrentUserInfo
+  @GetMapping("/info/dance-classes")
+  @AssignOrNullCurrentUserInfo
   public ApiResponse<DanceClassListServiceResponse> getDancerClasses(
       CurrentUserInfo userInfo,
       @RequestParam(required = false) @Min(1) Long dancerId,

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -67,7 +67,7 @@ public class DancerController {
   }
 
   @Operation(summary = "단일 댄서 정보 조회 API", description = "댄서의 정보를 조회합니다.")
-  @GetMapping("/{dancerId}")
+  @GetMapping("/info/{dancerId}")
   @AssignOrNullCurrentUserInfo
   public ApiResponse<DancerInfoResponse> getDancerInfo(
       CurrentUserInfo userInfo,
@@ -104,7 +104,6 @@ public class DancerController {
 
   @Operation(summary = "모든 댄서 정보 조회 API", description = "모든 댄서의 정보를 조회합니다.")
   @GetMapping("/all")
-  @AssignOrNullCurrentUserInfo
   public ApiResponse<DancerSummaryListResponse> getAllDancers() {
 
     DancerSummaryListResponse response = dancerService.getAllDancers();

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -9,6 +9,7 @@ import com.danthis.backend.application.dancer.DancerService;
 import com.danthis.backend.application.dancer.response.DancerInfoResponse;
 import com.danthis.backend.application.dancer.response.DancerSummaryListResponse;
 import com.danthis.backend.common.security.aop.AssignCurrentUserInfo;
+import com.danthis.backend.common.security.aop.AssignOrNullCurrentUserInfo;
 import com.danthis.backend.common.security.aop.CurrentUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,6 +40,7 @@ public class DancerController {
   public ApiResponse<Long> addDancer(
       CurrentUserInfo userInfo,
       @RequestBody @Valid DancerAddRequest request) {
+
     Long dancerId = dancerService.addDancerInfo(userInfo.getUserId(), request.toServiceRequest());
     return ApiResponse.OK(dancerId);
   }
@@ -49,6 +51,7 @@ public class DancerController {
   public ApiResponse<Long> updateDancer(
       CurrentUserInfo userInfo,
       @RequestBody @Valid DancerUpdateRequest request) {
+
     Long dancerId = dancerService.updateDancerInfo(userInfo.getUserId(), request.toServiceRequest());
     return ApiResponse.OK(dancerId);
   }
@@ -58,26 +61,30 @@ public class DancerController {
   @AssignCurrentUserInfo
   public ApiResponse<DancerInfoResponse> getMyDancerInfo(
       CurrentUserInfo userInfo) {
+
     DancerInfoResponse response = dancerService.getMyDancerInfo(userInfo.getUserId());
     return ApiResponse.OK(response);
   }
 
   @Operation(summary = "단일 댄서 정보 조회 API", description = "댄서의 정보를 조회합니다.")
   @GetMapping("/{dancerId}")
-  @AssignCurrentUserInfo
+  @AssignOrNullCurrentUserInfo
   public ApiResponse<DancerInfoResponse> getDancerInfo(
       CurrentUserInfo userInfo,
       @PathVariable("dancerId") Long dancerId) {
+
     DancerInfoResponse response = dancerService.getDancerInfo(userInfo.getUserId(), dancerId);
     return ApiResponse.OK(response);
   }
 
   @Operation(summary = "장르별 댄서 정보 조회 API", description = "장르별 댄서들의 정보를 조회합니다.")
   @GetMapping("/genres/{genreId}")
+  @AssignOrNullCurrentUserInfo
   public ApiResponse<DancerSummaryListResponse> getDancersByGenre(
       @PathVariable("genreId") Long genreId,
       @RequestParam(defaultValue = "1") @Min(1) Integer page,
       @RequestParam(defaultValue = "9") @Min(1) Integer size) {
+
     DancerSummaryListResponse response = dancerService.getDancersByGenre(genreId, page, size);
     return ApiResponse.OK(response);
   }
@@ -97,7 +104,9 @@ public class DancerController {
 
   @Operation(summary = "모든 댄서 정보 조회 API", description = "모든 댄서의 정보를 조회합니다.")
   @GetMapping("/all")
+  @AssignOrNullCurrentUserInfo
   public ApiResponse<DancerSummaryListResponse> getAllDancers() {
+
     DancerSummaryListResponse response = dancerService.getAllDancers();
     return ApiResponse.OK(response);
   }
@@ -105,7 +114,9 @@ public class DancerController {
   @Operation(summary = "사용자 장르 맞춤 댄서 추천 API", description = "사용자의 선호 장르를 기반으로 해당 장르를 주장르로 하는 댄서를 조회합니다.")
   @GetMapping("/recommendations")
   @AssignCurrentUserInfo
-  public ApiResponse<DancerSummaryListResponse> getRecommendationDancers(CurrentUserInfo userInfo) {
+  public ApiResponse<DancerSummaryListResponse> getRecommendationDancers(
+      CurrentUserInfo userInfo) {
+
     DancerSummaryListResponse response = dancerService.getRecommendationDancers(userInfo.getUserId());
     return ApiResponse.OK(response);
   }

--- a/src/main/java/com/danthis/backend/api/dancer/DancerController.java
+++ b/src/main/java/com/danthis/backend/api/dancer/DancerController.java
@@ -83,7 +83,7 @@ public class DancerController {
   public ApiResponse<DancerSummaryListResponse> getDancersByGenre(
       @PathVariable("genreId") Long genreId,
       @RequestParam(defaultValue = "1") @Min(1) Integer page,
-      @RequestParam(defaultValue = "9") @Min(1) Integer size) {
+      @RequestParam(defaultValue = "6") @Min(1) Integer size) {
 
     DancerSummaryListResponse response = dancerService.getDancersByGenre(genreId, page, size);
     return ApiResponse.OK(response);

--- a/src/main/java/com/danthis/backend/api/review/ReviewController.java
+++ b/src/main/java/com/danthis/backend/api/review/ReviewController.java
@@ -40,7 +40,7 @@ public class ReviewController {
   }
 
   @Operation(summary = "리뷰 단일 조회 API", description = "특정 댄스 수업의 리뷰를 단일 조회합니다.")
-  @GetMapping("dance-classes/{classId}/reviews/{reviewId}")
+  @GetMapping("dance-classes/info/{classId}/reviews/{reviewId}")
   @AssignCurrentUserInfo
   public ApiResponse<ReviewReadServiceResponse> getReview(
       @PathVariable Long classId,

--- a/src/main/java/com/danthis/backend/application/community/implement/CommentMapper.java
+++ b/src/main/java/com/danthis/backend/application/community/implement/CommentMapper.java
@@ -29,6 +29,7 @@ public class CommentMapper {
                                                 .map(
                                                     comment -> CommentListServiceResponse.CommentSummary.builder()
                                                                                                         .commentId(comment.getId())
+                                                                                                        .userId(comment.getUser().getId())
                                                                                                         .userName(comment.getUser().getNickname())
                                                                                                         .userProfileImage(comment.getUser().getProfileImage())
                                                                                                         .createdAt(comment.getCreatedAt())

--- a/src/main/java/com/danthis/backend/application/community/implement/PostMapper.java
+++ b/src/main/java/com/danthis/backend/application/community/implement/PostMapper.java
@@ -31,6 +31,7 @@ public class PostMapper {
 
     return PostReadServiceResponse.builder()
                                   .postId(post.getId())
+                                  .userId(post.getUser().getId())
                                   .title(post.getTitle())
                                   .author(post.getUser().getNickname())
                                   .createdAt(post.getCreatedAt())

--- a/src/main/java/com/danthis/backend/application/community/response/CommentListServiceResponse.java
+++ b/src/main/java/com/danthis/backend/application/community/response/CommentListServiceResponse.java
@@ -20,6 +20,7 @@ public class CommentListServiceResponse {
   public static class CommentSummary {
 
     private Long commentId;
+    private Long userId;
     private String userName;
     private String userProfileImage;
     private LocalDateTime createdAt;

--- a/src/main/java/com/danthis/backend/application/community/response/PostReadServiceResponse.java
+++ b/src/main/java/com/danthis/backend/application/community/response/PostReadServiceResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public class PostReadServiceResponse {
 
   private Long postId;
+  private Long userId;
   private String title;
   private String author;
   private LocalDateTime createdAt;

--- a/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
+++ b/src/main/java/com/danthis/backend/application/danceclass/DanceClassService.java
@@ -184,18 +184,20 @@ public class DanceClassService {
   @Transactional
   public DanceClassListServiceResponse getDancerClasses(Long userId, Long dancerId, Integer page,
       Integer size) {
+
     PageRequest pageable = PageRequest.of(page - 1, size);
-    Dancer dancer = dancerReader.readDancerByUserId(userId);
     if (dancerId != null) {
-      dancer = dancerReader.readDancerById(dancerId);
+      Page<DanceClass> danceClasses = danceClassReader.readDancerClasses(dancerId, pageable);
+      return DanceClassListServiceResponse.from(danceClasses);
     }
 
-    if (dancer == null) {
-      throw new BusinessException(ErrorCode.DANCER_NOT_FOUND);
+    if (userId != null) {
+      Dancer dancer = dancerReader.readDancerById(userId);
+      Page<DanceClass> danceClasses = danceClassReader.readDancerClasses(dancer.getId(), pageable);
+      return DanceClassListServiceResponse.from(danceClasses);
     }
 
-    Page<DanceClass> danceClasses = danceClassReader.readDancerClasses(dancer.getId(), pageable);
-    return DanceClassListServiceResponse.from(danceClasses);
+    throw new BusinessException(ErrorCode.DANCER_NOT_FOUND);
   }
 
   @Transactional

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -93,19 +93,13 @@ public class DancerService {
 
   @Transactional
   public DancerInfoResponse getMyDancerInfo(Long userId) {
-    User user = userReader.readUserById(userId);
     Dancer dancer = dancerReader.readDancerByUserId(userId);
-
-    // 이미 찜이 된 경우 true, 찜이 안되어 있으면 false 저장
-    boolean isFavorite = userDancerReader.readUserDancerByUserAndDancer(user, dancer) != null;
-
     return DancerInfoResponse.builder()
                              .id(dancer.getId())
                              .dancerName(dancer.getDancerName())
                              .instargramId(dancer.getInstargramId())
                              .bio(dancer.getBio())
                              .history(dancer.getHistory())
-                             .isFavorite(isFavorite)
                              .openChatUrl(dancer.getOpenChatUrl())
                              .preferredGenres(dancerGenreReader.findGenreIdByDancer(dancer))
                              .dancerImages(dancerImageReader.findImageUrlByDancer(dancer))
@@ -114,11 +108,14 @@ public class DancerService {
 
   @Transactional
   public DancerInfoResponse getDancerInfo(Long userId, Long dancerId) {
-    User user = userReader.readUserById(userId);
     Dancer dancer = dancerReader.readDancerById(dancerId);
+    boolean isFavorite = false;
 
-    // 이미 찜이 된 경우 true, 찜이 안되어 있으면 false 저장
-    boolean isFavorite = userDancerReader.readUserDancerByUserAndDancer(user, dancer) != null;
+    if (dancerId != null) {
+      User user = userReader.readUserById(userId);
+      // 이미 찜이 된 경우 true, 찜이 안되어 있으면 false 저장
+      isFavorite = userDancerReader.readUserDancerByUserAndDancer(user, dancer) != null;
+    }
 
     return DancerInfoResponse.builder()
                              .id(dancer.getId())

--- a/src/main/java/com/danthis/backend/application/dancer/DancerService.java
+++ b/src/main/java/com/danthis/backend/application/dancer/DancerService.java
@@ -111,7 +111,7 @@ public class DancerService {
     Dancer dancer = dancerReader.readDancerById(dancerId);
     boolean isFavorite = false;
 
-    if (dancerId != null) {
+    if (userId != null) {
       User user = userReader.readUserById(userId);
       // 이미 찜이 된 경우 true, 찜이 안되어 있으면 false 저장
       isFavorite = userDancerReader.readUserDancerByUserAndDancer(user, dancer) != null;

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -48,7 +48,9 @@ public class SecurityConfig {
                 "/auth/reissue",
                 "/exception/**",
                 "/dance-classes/all",
-                "/dancers/all"
+                "/dancers/all",
+                "/dancers/genres/",
+                "/dancers/"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 "/dance-classes/all",
                 "/dancers/all",
                 "/dancers/genres/*",
-                "/dancers/*"
+                "/dancers/info/*"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -49,8 +49,8 @@ public class SecurityConfig {
                 "/exception/**",
                 "/dance-classes/all",
                 "/dancers/all",
-                "/dancers/genres/",
-                "/dancers/"
+                "/dancers/genres/*",
+                "/dancers/*"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 "/dance-classes/all",
                 "/dancers/all",
                 "/dancers/genres/*",
-                "/dancers/info/*"
+                "/dancers/info/**"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                 "/dancers/all",
                 "/dancers/genres/*",
                 "/dancers/info/**",
-                "/dance-classes/info/**"
+                "/dance-classes/info/**",
+                "/community/info/**"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                 "/dance-classes/all",
                 "/dancers/all",
                 "/dancers/genres/*",
-                "/dancers/info/**"
+                "/dancers/info/**",
+                "/dance-classes/info/**"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
@@ -112,6 +112,7 @@ public class JwtFilter extends OncePerRequestFilter {
           uri.equals("/auth/reissue") ||
           uri.startsWith("/dancers/info") ||
           uri.startsWith("/dance-classes/info") ||
+          uri.startsWith("/community/info") ||
           uri.startsWith("/dancers/genres")) {
         return true;
       }

--- a/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
@@ -109,7 +109,9 @@ public class JwtFilter extends OncePerRequestFilter {
     if ("GET".equals(method)) {
       if (uri.startsWith("/dancers/all") ||
           uri.startsWith("/dance-classes/all") ||
-          uri.equals("/auth/reissue")) {
+          uri.equals("/auth/reissue") ||
+          uri.startsWith("/dancers/info") ||
+          uri.startsWith("/dancers/genres")) {
         return true;
       }
     }

--- a/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
@@ -111,6 +111,7 @@ public class JwtFilter extends OncePerRequestFilter {
           uri.startsWith("/dance-classes/all") ||
           uri.equals("/auth/reissue") ||
           uri.startsWith("/dancers/info") ||
+          uri.startsWith("/dance-classes/info") ||
           uri.startsWith("/dancers/genres")) {
         return true;
       }


### PR DESCRIPTION
## 💡 연관된 이슈
close #103 

ex) #이슈번호, #이슈번호

## 📝 작업 내용
* SecurityConfig에 비로그인시에도 사용이 필요한 댄서 api 추가
* 장르별 댄서조회 기본 사이즈 9 -> 6으로 수정

## 💬 리뷰 요구 사항
특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
