### PR TITLE
[Feature] 연습실 위치, 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/danthis/backend/api/practiceroom/PracticeRoomController.java
+++ b/src/main/java/com/danthis/backend/api/practiceroom/PracticeRoomController.java
@@ -21,14 +21,22 @@ public class PracticeRoomController {
   private final PracticeRoomService practiceRoomService;
 
   @Operation(summary = "주위 연습실 조회 API", description = "경도, 위도 기준 주위 연습실 정보를 조회합니다.")
-  @GetMapping("/info")
+  @GetMapping("/info/surround")
   @AssignOrNullCurrentUserInfo
   public ApiResponse<PracticeRoomListResponse> getPracticeRooomInfo(
       @RequestParam Double longitude,
       @RequestParam Double latitude,
       @RequestParam(defaultValue = "0.5") Double radius) {
-    PracticeRoomListResponse response = practiceRoomService.getAllPracticeRoom(
+    PracticeRoomListResponse response = practiceRoomService.getPracticeRoomsByLocation(
         longitude, latitude, radius);
+    return ApiResponse.OK(response);
+  }
+
+  @Operation(summary = "모든 연습실 조회 API")
+  @GetMapping("/info/all")
+  @AssignOrNullCurrentUserInfo
+  public ApiResponse<PracticeRoomListResponse> getAllPracticeRooomInfo() {
+    PracticeRoomListResponse response = practiceRoomService.getAllPracticeRoom();
     return ApiResponse.OK(response);
   }
 }

--- a/src/main/java/com/danthis/backend/api/practiceroom/PracticeRoomController.java
+++ b/src/main/java/com/danthis/backend/api/practiceroom/PracticeRoomController.java
@@ -1,0 +1,34 @@
+package com.danthis.backend.api.practiceroom;
+
+import com.danthis.backend.api.ApiResponse;
+import com.danthis.backend.application.practiceroom.PracticeRoomService;
+import com.danthis.backend.application.practiceroom.response.PracticeRoomListResponse;
+import com.danthis.backend.common.security.aop.AssignOrNullCurrentUserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/practice-rooms")
+@RequiredArgsConstructor
+@Tag(name = "연습실 API 관련 컨트롤러")
+public class PracticeRoomController {
+
+  private final PracticeRoomService practiceRoomService;
+
+  @Operation(summary = "주위 연습실 조회 API", description = "경도, 위도 기준 주위 연습실 정보를 조회합니다.")
+  @GetMapping("/info")
+  @AssignOrNullCurrentUserInfo
+  public ApiResponse<PracticeRoomListResponse> getPracticeRooomInfo(
+      @RequestParam Double longitude,
+      @RequestParam Double latitude,
+      @RequestParam(defaultValue = "0.5") Double radius) {
+    PracticeRoomListResponse response = practiceRoomService.getAllPracticeRoom(
+        longitude, latitude, radius);
+    return ApiResponse.OK(response);
+  }
+}

--- a/src/main/java/com/danthis/backend/application/practiceroom/PracticeRoomService.java
+++ b/src/main/java/com/danthis/backend/application/practiceroom/PracticeRoomService.java
@@ -17,13 +17,18 @@ public class PracticeRoomService {
 
   private final PracticeRoomReader practiceRoomReader;
 
-  public PracticeRoomListResponse getAllPracticeRoom(Double longitude, Double latitude,
+  public PracticeRoomListResponse getPracticeRoomsByLocation(Double longitude, Double latitude,
       Double radius) {
 
     if (radius < 0) {
       throw new BusinessException(ErrorCode.INVALID_NEGATIVE_NUMBER);
     }
     List<PracticeRoom> practiceRooms = practiceRoomReader.getRooms(longitude, latitude, radius);
+    return PracticeRoomListResponse.of(practiceRooms);
+  }
+
+  public PracticeRoomListResponse getAllPracticeRoom() {
+    List<PracticeRoom> practiceRooms = practiceRoomReader.getAllRooms();
     return PracticeRoomListResponse.of(practiceRooms);
   }
 }

--- a/src/main/java/com/danthis/backend/application/practiceroom/PracticeRoomService.java
+++ b/src/main/java/com/danthis/backend/application/practiceroom/PracticeRoomService.java
@@ -1,0 +1,29 @@
+package com.danthis.backend.application.practiceroom;
+
+import com.danthis.backend.application.practiceroom.implement.PracticeRoomReader;
+import com.danthis.backend.application.practiceroom.response.PracticeRoomListResponse;
+import com.danthis.backend.common.exception.BusinessException;
+import com.danthis.backend.common.exception.ErrorCode;
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PracticeRoomService {
+
+  private final PracticeRoomReader practiceRoomReader;
+
+  public PracticeRoomListResponse getAllPracticeRoom(Double longitude, Double latitude,
+      Double radius) {
+
+    if (radius < 0) {
+      throw new BusinessException(ErrorCode.INVALID_NEGATIVE_NUMBER);
+    }
+    List<PracticeRoom> practiceRooms = practiceRoomReader.getRooms(longitude, latitude, radius);
+    return PracticeRoomListResponse.of(practiceRooms);
+  }
+}

--- a/src/main/java/com/danthis/backend/application/practiceroom/implement/PracticeRoomReader.java
+++ b/src/main/java/com/danthis/backend/application/practiceroom/implement/PracticeRoomReader.java
@@ -1,0 +1,19 @@
+package com.danthis.backend.application.practiceroom.implement;
+
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import com.danthis.backend.domain.practiceroom.repository.PracticeRoomRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PracticeRoomReader {
+
+  private final PracticeRoomRepository practiceRoomRepository;
+
+  public List<PracticeRoom> getRooms(Double longitude, Double latitude, Double radius) {
+    return practiceRoomRepository.findAllByLocation(
+        longitude, latitude, radius);
+  }
+}

--- a/src/main/java/com/danthis/backend/application/practiceroom/implement/PracticeRoomReader.java
+++ b/src/main/java/com/danthis/backend/application/practiceroom/implement/PracticeRoomReader.java
@@ -16,4 +16,8 @@ public class PracticeRoomReader {
     return practiceRoomRepository.findAllByLocation(
         longitude, latitude, radius);
   }
+
+  public List<PracticeRoom> getAllRooms() {
+    return practiceRoomRepository.findAll();
+  }
 }

--- a/src/main/java/com/danthis/backend/application/practiceroom/response/PracticeRoomListResponse.java
+++ b/src/main/java/com/danthis/backend/application/practiceroom/response/PracticeRoomListResponse.java
@@ -1,0 +1,43 @@
+package com.danthis.backend.application.practiceroom.response;
+
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PracticeRoomListResponse {
+
+  private List<PracticeRoomInfo> practiceRooms;
+  private Integer totalElements;
+
+
+  @Getter
+  @Builder
+  private static class PracticeRoomInfo {
+
+    private Long id;
+    private String name;
+    private Double longitude;
+    private Double latitude;
+  }
+
+  public static PracticeRoomListResponse of(List<PracticeRoom> practiceRooms) {
+    List<PracticeRoomInfo> practiceRoomInfos =
+        practiceRooms.stream()
+                     .map(
+                         room -> PracticeRoomInfo.builder()
+                                                 .id(room.getId())
+                                                 .name(room.getName())
+                                                 .latitude(room.getLatitude())
+                                                 .longitude(room.getLongitude())
+                                                 .build()
+                     ).toList();
+    
+    return PracticeRoomListResponse.builder()
+                                   .practiceRooms(practiceRoomInfos)
+                                   .totalElements(practiceRoomInfos.size())
+                                   .build();
+  }
+}

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -52,7 +52,8 @@ public class SecurityConfig {
                 "/dancers/genres/*",
                 "/dancers/info/**",
                 "/dance-classes/info/**",
-                "/community/info/**"
+                "/community/info/**",
+                "/practice-rooms/info"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/danthis/backend/common/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 "/dancers/info/**",
                 "/dance-classes/info/**",
                 "/community/info/**",
-                "/practice-rooms/info"
+                "/practice-rooms/info/**"
             ).permitAll()
             .requestMatchers(HttpMethod.POST,
                 "/auth/login/kakao",

--- a/src/main/java/com/danthis/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/danthis/backend/common/exception/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
   POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다"),
   COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
   INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 날짜 형식입니다."),
-  INVALID_DAY_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 요일 형식입니다.");
+  INVALID_DAY_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 요일 형식입니다."),
+  INVALID_NEGATIVE_NUMBER(HttpStatus.BAD_REQUEST, "양수값만 사용 가능합니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
+++ b/src/main/java/com/danthis/backend/common/security/jwt/JwtFilter.java
@@ -113,7 +113,8 @@ public class JwtFilter extends OncePerRequestFilter {
           uri.startsWith("/dancers/info") ||
           uri.startsWith("/dance-classes/info") ||
           uri.startsWith("/community/info") ||
-          uri.startsWith("/dancers/genres")) {
+          uri.startsWith("/dancers/genres") ||
+          uri.startsWith("/practice-rooms/info")) {
         return true;
       }
     }

--- a/src/main/java/com/danthis/backend/domain/practiceroom/PracticeRoom.java
+++ b/src/main/java/com/danthis/backend/domain/practiceroom/PracticeRoom.java
@@ -1,0 +1,33 @@
+package com.danthis.backend.domain.practiceroom;
+
+import com.danthis.backend.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class PracticeRoom extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 50)
+  private String name;
+
+  @Column(nullable = false)
+  private Double longitude;
+
+  @Column(nullable = false)
+  private Double latitude;
+}

--- a/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepository.java
+++ b/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepository.java
@@ -1,0 +1,10 @@
+package com.danthis.backend.domain.practiceroom.repository;
+
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PracticeRoomRepository extends JpaRepository<PracticeRoom, Long> {
+
+}

--- a/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepository.java
+++ b/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PracticeRoomRepository extends JpaRepository<PracticeRoom, Long> {
+public interface PracticeRoomRepository extends
+    JpaRepository<PracticeRoom, Long>, PracticeRoomRepositoryCustom {
 
 }

--- a/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepositoryCustom.java
+++ b/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.danthis.backend.domain.practiceroom.repository;
+
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import java.util.List;
+
+public interface PracticeRoomRepositoryCustom {
+
+  List<PracticeRoom> findAllByLocation(Double longitude, Double latitude, Double radius);
+}

--- a/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/practiceroom/repository/PracticeRoomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.danthis.backend.domain.practiceroom.repository;
+
+import com.danthis.backend.domain.practiceroom.PracticeRoom;
+import com.danthis.backend.domain.practiceroom.QPracticeRoom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PracticeRoomRepositoryImpl implements PracticeRoomRepositoryCustom {
+
+  private final JPAQueryFactory jpaQueryFactory;
+  private final QPracticeRoom qPracticeRoom = QPracticeRoom.practiceRoom;
+
+  @Override
+  public List<PracticeRoom> findAllByLocation(Double longitude, Double latitude, Double radius) {
+    return jpaQueryFactory.selectFrom(qPracticeRoom)
+                          .where(
+                              qPracticeRoom.latitude.between(latitude - radius, latitude + radius),
+                              qPracticeRoom.longitude.between(longitude - radius,
+                                  longitude + radius)
+                          ).fetch();
+  }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #110 

ex) #이슈번호, #이슈번호

## 📝 작업 내용
* 연습실 엔티티 생성 (PracticeRoom)
   * field 구성은 다음과 같습니다.
   * Long id
   * String name
   * Double latitude (위도)
   * Double longitued (경도)
 * 위도, 경도 기반 주변 연습실 조회 기능 구현
   * 쿼리 파라미터로 위도, 경도, 반지름 값을 받아 해당 범위 내 연습실 정보 리스트를 반환합니다.
   * 쿼리는 between 메서드를 사용해서 범위 내 값을 찾습니다.
 * 모든 연습실 조회 기능 구현

## 💬 리뷰 요구 사항
비로그인 환경에서도 api를 사용할 수 있도록 SecurityConfig 파일과 JwtFilter 파일에서 매번 api의 uri를 허용하도록 추가하고 있는데,
이런 방식이 맞는지, 대대적인 api uri 수정이 필요할지 궁금합니다.
당장 적용하지 않더라도 다음번에는 uri 설계할때부터 참고할 수 있도록 장원이 의견이 궁금해요!