### PR TITLE
[Fix] 도커파일 java17 sdk 이미지 수정

### DIFF
--- a/.github/workflows/danthis_dev.yml
+++ b/.github/workflows/danthis_dev.yml
@@ -78,7 +78,7 @@ jobs:
         run: echo "RUNNER_IP=$(curl -s ifconfig.me)" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # curl 설치
 RUN apt-get update \


### PR DESCRIPTION
## 💡 연관된 이슈
close #113 

ex) #이슈번호, #이슈번호

## 📝 작업 내용
기존 Dockerfile에서 사용중이던 `openjdk:17-jdk-slim` 이미지가 만료되어서 깃허브 액션에서 에러가 발생.
`eclipse-temurin:17-jdk-jammy` 이미지로 변경




참고 블로그:
https://velog.io/@dailyzett/%EC%A1%B0%EC%9A%A9%ED%9E%88-%EC%8B%A4%ED%8C%A8%ED%95%98%EB%8A%94-Docker-%EB%B0%B0%ED%8F%AC-%EC%97%90%EB%9F%AC%EA%B0%80-%EB%96%A0%EB%8F%84-%EB%B0%B0%ED%8F%AC%EB%90%98%EB%8A%94-%EC%9D%B4%EC%9C%A0


## 💬 리뷰 요구 사항
특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
