### PR TITLE
[Featuer] 댄스수업 조회 기능 수정 & 리뷰 목록 조회 정렬 변경

### DIFF
--- a/src/main/java/com/danthis/backend/application/danceclass/implement/DanceClassReader.java
+++ b/src/main/java/com/danthis/backend/application/danceclass/implement/DanceClassReader.java
@@ -64,24 +64,16 @@ public class DanceClassReader {
         return danceClassRepository.findByGenreId(genreId, pageable);
       }
 
-      if (date != null && day == null) { // 장르 + 날짜로 검색
-        LocalDate localDate;
-        try {
-          DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-          localDate = LocalDate.parse(date, formatter);
-        } catch (Exception e) {
-          throw new BusinessException(ErrorCode.INVALID_DATE_FORMAT);
+      if (date != null) { // 장르 + 날짜 + 요일로 검색
+        LocalDate localDate = convertToLocalDate(date);
+        if (day == null) {  // 요일 정보가 없으면 날짜로만 검색
+          return danceClassRepository.findByGenreIdAndDate(genreId, localDate, pageable);
+        } else {    // 요일 정보가 있으면 함께 검색
+          Week week = convertToWeek(day);
+          return danceClassRepository.findByGenreIdAndDateOrDay(genreId, localDate, week, pageable);
         }
-        return danceClassRepository.findByGenreIdAndDate(genreId, localDate, pageable);
-      }
-
-      if (date == null && day != null) { // 장르 + 요일로 검색
-        Week week;
-        try {
-          week = Week.valueOf(day);
-        } catch (IllegalArgumentException e) {
-          throw new BusinessException(ErrorCode.INVALID_DAY_FORMAT);
-        }
+      } else { // 날짜 정보가 없다면 장르 + 요일로 검색
+        Week week = convertToWeek(day);
         return danceClassRepository.findByGenreIdAndDay(genreId, week, pageable);
       }
     }
@@ -122,5 +114,22 @@ public class DanceClassReader {
 
   public List<DanceClass> readDanceClassesByGenres(Set<Long> genreIds) {
     return danceClassRepository.findByGenreIds(genreIds);
+  }
+
+  private LocalDate convertToLocalDate(String date) {
+    try {
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+      return LocalDate.parse(date, formatter);
+    } catch (Exception e) {
+      throw new BusinessException(ErrorCode.INVALID_DATE_FORMAT);
+    }
+  }
+
+  private Week convertToWeek(String day) {
+    try {
+      return Week.valueOf(day);
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(ErrorCode.INVALID_DAY_FORMAT);
+    }
   }
 }

--- a/src/main/java/com/danthis/backend/application/user/UserService.java
+++ b/src/main/java/com/danthis/backend/application/user/UserService.java
@@ -40,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -170,7 +171,8 @@ public class UserService {
 
   @Transactional
   public UserReviewResponse getUserReviews(Long userId, Integer page, Integer size) {
-    PageRequest pageable = PageRequest.of(page - 1, size);
+    PageRequest pageable = PageRequest.of(
+        page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<ClassReview> reviews = reviewReader.readReviewsByUserId(userId, pageable);
     List<ReviewDto> reviewDtoList = reviewManager.toReviewDtoList(reviews.getContent());
 

--- a/src/main/java/com/danthis/backend/application/user/UserService.java
+++ b/src/main/java/com/danthis/backend/application/user/UserService.java
@@ -40,7 +40,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -172,7 +171,7 @@ public class UserService {
   @Transactional
   public UserReviewResponse getUserReviews(Long userId, Integer page, Integer size) {
     PageRequest pageable = PageRequest.of(
-        page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        page - 1, size);
     Page<ClassReview> reviews = reviewReader.readReviewsByUserId(userId, pageable);
     List<ReviewDto> reviewDtoList = reviewManager.toReviewDtoList(reviews.getContent());
 

--- a/src/main/java/com/danthis/backend/domain/classreview/repository/ClassReviewRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/classreview/repository/ClassReviewRepositoryImpl.java
@@ -33,6 +33,7 @@ public class ClassReviewRepositoryImpl implements ClassReviewRepositoryCustom {
     List<ClassReview> reviews = jpaQueryFactory.selectFrom(classReview)
                                                .where(classReview.user.id.eq(userId).and(
                                                    classReview.isActive.eq(true)))
+                                               .orderBy(classReview.createdAt.desc())
                                                .offset(pageable.getOffset())
                                                .limit(pageable.getPageSize())
                                                .fetch();

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryCustom.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryCustom.java
@@ -15,4 +15,7 @@ public interface DanceClassRepositoryCustom {
   Page<DanceClass> findByGenreIdAndDay(Long genreId, Week day, PageRequest pageable);
 
   List<DanceClass> findByGenreIds(Set<Long> genreIds);
+
+  Page<DanceClass> findByGenreIdAndDateOrDay(Long genreId, LocalDate localDate, Week day,
+      PageRequest pageable);
 }

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
@@ -74,6 +74,7 @@ public class DanceClassRepositoryImpl implements DanceClassRepositoryCustom {
         .select(danceClass.count())
         .distinct()
         .from(danceClass)
+        .join(danceClass.danceClassSchedules, danceClassSchedule)
         .where(
             danceClass.isActive.eq(true),
             danceClass.genre.id.eq(genreId),

--- a/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
+++ b/src/main/java/com/danthis/backend/domain/danceclass/repository/DanceClassRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.danthis.backend.domain.danceclass.danceclassschedule.Week;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,7 +39,19 @@ public class DanceClassRepositoryImpl implements DanceClassRepositoryCustom {
         .limit(pageable.getPageSize())
         .fetch();
 
-    return new PageImpl<>(danceClasses, pageable, danceClasses.size());
+    long total = Optional.ofNullable(jpaQueryFactory
+        .select(danceClass.count()) // join 시 중복이 발생하므로 countDistinct 사용
+        .distinct()
+        .from(danceClass)
+        .join(danceClass.danceClassSchedules, danceClassSchedule)
+        .where(
+            danceClass.isActive.eq(true),
+            danceClass.genre.id.eq(genreId),
+            danceClassSchedule.date.eq(date)
+        )
+        .fetchOne()).orElse(0L);
+
+    return new PageImpl<>(danceClasses, pageable, total);
   }
 
   @Override
@@ -57,7 +70,18 @@ public class DanceClassRepositoryImpl implements DanceClassRepositoryCustom {
         .limit(pageable.getPageSize())
         .fetch();
 
-    return new PageImpl<>(danceClasses, pageable, danceClasses.size());
+    long total = Optional.ofNullable(jpaQueryFactory
+        .select(danceClass.count())
+        .distinct()
+        .from(danceClass)
+        .where(
+            danceClass.isActive.eq(true),
+            danceClass.genre.id.eq(genreId),
+            danceClassSchedule.day.eq(day)
+        )
+        .fetchOne()).orElse(0L);
+
+    return new PageImpl<>(danceClasses, pageable, total);
   }
 
   @Override
@@ -65,5 +89,38 @@ public class DanceClassRepositoryImpl implements DanceClassRepositoryCustom {
     return jpaQueryFactory.selectFrom(danceClass)
                           .where(danceClass.genre.id.in(genreIds))
                           .fetch();
+  }
+
+  @Override
+  public Page<DanceClass> findByGenreIdAndDateOrDay(Long genreId, LocalDate date, Week day,
+      PageRequest pageable) {
+
+    List<DanceClass> danceClasses = jpaQueryFactory
+        .selectFrom(danceClass)
+        .distinct()
+        .join(danceClass.danceClassSchedules, danceClassSchedule)
+        .where(
+            danceClass.isActive.eq(true),
+            danceClass.genre.id.eq(genreId),
+            danceClassSchedule.date.eq(date).or(danceClassSchedule.day.eq(day))
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(danceClass.createdAt.desc()) // 최신순 정렬
+        .fetch();
+
+    long total = Optional.ofNullable(jpaQueryFactory
+        .select(danceClass.count()) // join 시 중복이 발생하므로 countDistinct 사용
+        .distinct()
+        .from(danceClass)
+        .join(danceClass.danceClassSchedules, danceClassSchedule)
+        .where(
+            danceClass.isActive.eq(true),
+            danceClass.genre.id.eq(genreId),
+            danceClassSchedule.date.eq(date).or(danceClassSchedule.day.eq(day))
+        )
+        .fetchOne()).orElse(0L);
+
+    return new PageImpl<>(danceClasses, pageable, total);
   }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
#131 

ex) #이슈번호, #이슈번호

## 📝 작업 내용
댄스 수업 예약 페이지에서 댄스 수업 검색 시 요일과 날짜를 함께 검색하도록 수정
마이페이지에서 자신이 작성한  리뷰 목록 조회 시 최신순으로 정렬하도록 변경

## 💬 리뷰 요구 사항
특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
